### PR TITLE
Introduce revision control detection scaffold

### DIFF
--- a/codex-rs/core/src/git_info.rs
+++ b/codex-rs/core/src/git_info.rs
@@ -11,35 +11,7 @@ use tokio::process::Command;
 use tokio::time::Duration as TokioDuration;
 use tokio::time::timeout;
 
-/// Return `true` if the project folder specified by the `Config` is inside a
-/// Git repository.
-///
-/// The check walks up the directory hierarchy looking for a `.git` file or
-/// directory (note `.git` can be a file that contains a `gitdir` entry). This
-/// approach does **not** require the `git` binary or the `git2` crate and is
-/// therefore fairly lightweight.
-///
-/// Note that this does **not** detect *work‑trees* created with
-/// `git worktree add` where the checkout lives outside the main repository
-/// directory. If you need Codex to work from such a checkout simply pass the
-/// `--allow-no-git-exec` CLI flag that disables the repo requirement.
-pub fn get_git_repo_root(base_dir: &Path) -> Option<PathBuf> {
-    let mut dir = base_dir.to_path_buf();
-
-    loop {
-        if dir.join(".git").exists() {
-            return Some(dir);
-        }
-
-        // Pop one component (go up one directory).  `pop` returns false when
-        // we have reached the filesystem root.
-        if !dir.pop() {
-            break;
-        }
-    }
-
-    None
-}
+pub use crate::revision_control::git::get_git_repo_root;
 
 /// Timeout for git commands to prevent freezing on large repositories
 const GIT_COMMAND_TIMEOUT: TokioDuration = TokioDuration::from_secs(5);

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -108,3 +108,4 @@ pub use codex_protocol::models::ReasoningItemContent;
 pub use codex_protocol::models::ResponseItem;
 
 pub mod otel_init;
+pub mod revision_control;

--- a/codex-rs/core/src/revision_control/git.rs
+++ b/codex-rs/core/src/revision_control/git.rs
@@ -1,0 +1,53 @@
+use std::path::Path;
+use std::path::PathBuf;
+
+/// Return `true` if the project folder specified by the `Config` is inside a
+/// Git repository.
+///
+/// The check walks up the directory hierarchy looking for a `.git` file or
+/// directory (note `.git` can be a file that contains a `gitdir` entry). This
+/// approach does **not** require the `git` binary or the `git2` crate and is
+/// therefore fairly lightweight.
+///
+/// Note that this does **not** detect *work-trees* created with
+/// `git worktree add` where the checkout lives outside the main repository
+/// directory. If you need Codex to work from such a checkout simply pass the
+/// `--allow-no-git-exec` CLI flag that disables the repo requirement.
+pub fn get_git_repo_root(base_dir: &Path) -> Option<PathBuf> {
+    let mut dir = base_dir.to_path_buf();
+
+    loop {
+        if dir.join(".git").exists() {
+            return Some(dir);
+        }
+
+        if !dir.pop() {
+            break;
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn detects_nested_git_repository() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
+
+        let subdir = dir.path().join("nested");
+        std::fs::create_dir(&subdir).unwrap();
+
+        assert_eq!(get_git_repo_root(&subdir), Some(dir.path().to_path_buf()));
+    }
+
+    #[test]
+    fn returns_none_for_non_repo() {
+        let dir = tempdir().unwrap();
+        assert!(get_git_repo_root(dir.path()).is_none());
+    }
+}

--- a/codex-rs/core/src/revision_control/mod.rs
+++ b/codex-rs/core/src/revision_control/mod.rs
@@ -1,0 +1,63 @@
+use std::path::{Path, PathBuf};
+
+pub mod git;
+
+/// Enumeration of revision control backends supported by Codex.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RevisionControlKind {
+    Git,
+    Darcs,
+}
+
+/// Information about the detected revision control system for a workspace.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DetectedRevisionControl {
+    pub kind: RevisionControlKind,
+    pub root: PathBuf,
+}
+
+impl DetectedRevisionControl {
+    pub fn new(kind: RevisionControlKind, root: PathBuf) -> Self {
+        Self { kind, root }
+    }
+}
+
+/// Attempt to detect the revision control backend rooted at `base_dir`.
+///
+/// The current implementation only recognises Git repositories. Future
+/// updates will extend this to Darcs while keeping the detection flow in one
+/// place so the rest of the codebase can rely on a single entry point.
+pub fn detect_revision_control(base_dir: &Path) -> Option<DetectedRevisionControl> {
+    git::get_git_repo_root(base_dir)
+        .map(|root| DetectedRevisionControl::new(RevisionControlKind::Git, root))
+}
+
+pub use git::get_git_repo_root;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn detects_git_repository() {
+        let dir = tempdir().unwrap();
+        let git_dir = dir.path().join(".git");
+        fs::create_dir(&git_dir).unwrap();
+
+        let detected = detect_revision_control(dir.path());
+
+        assert!(detected.is_some());
+        let detected = detected.unwrap();
+        assert_eq!(detected.kind, RevisionControlKind::Git);
+        assert_eq!(detected.root, dir.path());
+    }
+
+    #[test]
+    fn returns_none_when_no_repo_found() {
+        let dir = tempdir().unwrap();
+
+        assert!(detect_revision_control(dir.path()).is_none());
+    }
+}

--- a/docs/git-and-github.md
+++ b/docs/git-and-github.md
@@ -9,7 +9,10 @@ implementation so the behavior can be replicated elsewhere.
   `--skip-git-repo-check` to protect users from destructive edits in ad-hoc directories.【F:docs/exec.md†L86-L88】
 * `codex_core::git_info::get_git_repo_root` walks up from the configured working directory until it finds a `.git`
   directory or file, allowing the application to decide whether Git features should be enabled without shelling out to
-  `git` itself.【F:codex-rs/core/src/git_info.rs†L17-L37】
+  `git` itself.【F:codex-rs/core/src/revision_control/git.rs†L1-L34】
+* `codex_core::revision_control::detect_revision_control` provides a single entry point for identifying the
+  repository backend. Today it returns Git repositories via the new abstraction, and future work will extend it to
+  recognise Darcs checkouts without forcing every caller to reimplement the detection logic.【F:codex-rs/core/src/revision_control/mod.rs†L1-L43】
 * When Codex is pointed at a non-Git directory, higher-level features such as ghost snapshots are disabled and the UI emits an
   informational message explaining why, preventing repeated failures.【F:codex-rs/tui/src/chatwidget.rs†L1288-L1322】
 

--- a/docs/queues/darcs.md
+++ b/docs/queues/darcs.md
@@ -2,6 +2,11 @@
 
 This queue tracks the Darcs support roadmap described in [docs/git-and-github.md](../git-and-github.md).
 
+Initial scaffolding for the abstraction now lives in
+`codex_core::revision_control`, which exposes a shared detection entry point
+so future Darcs-specific logic can slot in next to the existing Git
+implementation.【F:codex-rs/core/src/revision_control/mod.rs†L1-L43】
+
 ## Implementation roadmap & work queue
 
 ### 1. Abstract repository/revision detection


### PR DESCRIPTION
## Summary
- add a codex_core::revision_control module with enums for backend detection and a shared entry point
- move the Git repo root probe into the new module and add unit tests covering the detection helpers
- document the new abstraction in the Darcs queue and Git integration guide to explain the roadmap

## Testing
- cargo --offline fmt
- cargo test -p codex-core revision_control -- --nocapture


------
https://chatgpt.com/codex/tasks/task_e_68e708c0ade8832f9f002020f0855d59