### PR TITLE
feat: detect darcs repos during onboarding and config

### DIFF
--- a/codex-rs/common/src/config_summary.rs
+++ b/codex-rs/common/src/config_summary.rs
@@ -1,5 +1,6 @@
 use codex_core::WireApi;
 use codex_core::config::Config;
+use codex_core::revision_control::detect_revision_control;
 
 use crate::sandbox_summary::summarize_sandbox_policy;
 
@@ -12,6 +13,13 @@ pub fn create_config_summary_entries(config: &Config) -> Vec<(&'static str, Stri
         ("approval", config.approval_policy.to_string()),
         ("sandbox", summarize_sandbox_policy(&config.sandbox_policy)),
     ];
+
+    let revision_summary = match detect_revision_control(&config.cwd) {
+        Some(info) => format!("{} ({})", info.kind.display_name(), info.root.display()),
+        None => "none".to_string(),
+    };
+    entries.push(("revision", revision_summary));
+
     if config.model_provider.wire_api == WireApi::Responses
         && config.model_family.supports_reasoning_summaries
     {

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -17,7 +17,6 @@ use crate::config_types::ShellEnvironmentPolicy;
 use crate::config_types::ShellEnvironmentPolicyToml;
 use crate::config_types::Tui;
 use crate::config_types::UriBasedFileOpener;
-use crate::git_info::resolve_root_git_project_for_trust;
 use crate::model_family::ModelFamily;
 use crate::model_family::derive_default_model_family;
 use crate::model_family::find_family_for_model;
@@ -26,6 +25,7 @@ use crate::model_provider_info::built_in_model_providers;
 use crate::openai_model_info::get_model_info;
 use crate::protocol::AskForApproval;
 use crate::protocol::SandboxPolicy;
+use crate::revision_control::resolve_revision_control_project_for_trust;
 use anyhow::Context;
 use codex_app_server_protocol::Tools;
 use codex_app_server_protocol::UserSavedConfig;
@@ -908,10 +908,10 @@ impl ConfigToml {
             return true;
         }
 
-        // If cwd lives inside a git worktree, check whether the root git project
-        // (the primary repository working directory) is trusted. This lets
-        // worktrees inherit trust from the main project.
-        if let Some(root_project) = resolve_root_git_project_for_trust(resolved_cwd) {
+        // If cwd lives inside a revision-controlled project, check whether the
+        // repository root is trusted. This lets worktrees and other checkouts
+        // inherit trust from the main project.
+        if let Some(root_project) = resolve_revision_control_project_for_trust(resolved_cwd, None) {
             return is_path_trusted(&root_project);
         }
 

--- a/codex-rs/core/src/revision_control/mod.rs
+++ b/codex-rs/core/src/revision_control/mod.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use crate::git_info;
+
 pub mod darcs;
 pub mod git;
 
@@ -10,16 +12,81 @@ pub enum RevisionControlKind {
     Darcs,
 }
 
+impl RevisionControlKind {
+    /// Human readable display name for the backend.
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            Self::Git => "Git",
+            Self::Darcs => "Darcs",
+        }
+    }
+}
+
+/// Capabilities supported by the detected revision control backend.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct RevisionControlCapabilities {
+    pub supports_diffs: bool,
+    pub supports_snapshots: bool,
+}
+
+impl RevisionControlCapabilities {
+    pub const fn new(supports_diffs: bool, supports_snapshots: bool) -> Self {
+        Self {
+            supports_diffs,
+            supports_snapshots,
+        }
+    }
+
+    const fn for_kind(kind: RevisionControlKind) -> Self {
+        match kind {
+            RevisionControlKind::Git => Self::new(true, true),
+            // Darcs support is a work in progress. Report capabilities as disabled
+            // until the dedicated implementations land.
+            RevisionControlKind::Darcs => Self::new(false, false),
+        }
+    }
+}
+
+pub trait RevisionControlSystem {
+    fn kind(&self) -> RevisionControlKind;
+    fn root(&self) -> &Path;
+    fn capabilities(&self) -> RevisionControlCapabilities;
+
+    fn display_name(&self) -> &'static str {
+        self.kind().display_name()
+    }
+}
+
 /// Information about the detected revision control system for a workspace.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DetectedRevisionControl {
     pub kind: RevisionControlKind,
     pub root: PathBuf,
+    pub capabilities: RevisionControlCapabilities,
 }
 
 impl DetectedRevisionControl {
     pub fn new(kind: RevisionControlKind, root: PathBuf) -> Self {
-        Self { kind, root }
+        let capabilities = RevisionControlCapabilities::for_kind(kind);
+        Self {
+            kind,
+            root,
+            capabilities,
+        }
+    }
+}
+
+impl RevisionControlSystem for DetectedRevisionControl {
+    fn kind(&self) -> RevisionControlKind {
+        self.kind
+    }
+
+    fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn capabilities(&self) -> RevisionControlCapabilities {
+        self.capabilities
     }
 }
 
@@ -31,6 +98,21 @@ pub fn detect_revision_control(base_dir: &Path) -> Option<DetectedRevisionContro
 
     darcs::get_darcs_repo_root(base_dir)
         .map(|root| DetectedRevisionControl::new(RevisionControlKind::Darcs, root))
+}
+
+pub fn resolve_revision_control_project_for_trust(
+    base_dir: &Path,
+    detected: Option<&DetectedRevisionControl>,
+) -> Option<PathBuf> {
+    let detected = match detected {
+        Some(info) => info.clone(),
+        None => detect_revision_control(base_dir)?,
+    };
+
+    match detected.kind {
+        RevisionControlKind::Git => git_info::resolve_root_git_project_for_trust(base_dir),
+        RevisionControlKind::Darcs => Some(detected.root),
+    }
 }
 
 pub use git::get_git_repo_root;
@@ -53,6 +135,10 @@ mod tests {
         let detected = detected.unwrap();
         assert_eq!(detected.kind, RevisionControlKind::Git);
         assert_eq!(detected.root, dir.path());
+        assert_eq!(
+            detected.capabilities,
+            RevisionControlCapabilities::new(true, true)
+        );
     }
 
     #[test]
@@ -74,5 +160,20 @@ mod tests {
         let detected = detected.unwrap();
         assert_eq!(detected.kind, RevisionControlKind::Darcs);
         assert_eq!(detected.root, dir.path());
+        assert_eq!(
+            detected.capabilities,
+            RevisionControlCapabilities::new(false, false)
+        );
+    }
+
+    #[test]
+    fn resolve_trust_root_for_darcs_repo() {
+        let dir = tempdir().unwrap();
+        fs::create_dir(dir.path().join("_darcs")).unwrap();
+
+        let detected = detect_revision_control(dir.path()).unwrap();
+        let resolved = resolve_revision_control_project_for_trust(dir.path(), Some(&detected));
+
+        assert_eq!(resolved, Some(dir.path().to_path_buf()));
     }
 }

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -48,7 +48,7 @@ pub struct Cli {
     #[clap(long = "cd", short = 'C', value_name = "DIR")]
     pub cwd: Option<PathBuf>,
 
-    /// Allow running Codex outside a Git repository.
+    /// Allow running Codex outside a Git or Darcs repository.
     #[arg(long = "skip-git-repo-check", default_value_t = false)]
     pub skip_git_repo_check: bool,
 

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -17,7 +17,6 @@ use codex_core::ConversationManager;
 use codex_core::NewConversation;
 use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
-use codex_core::git_info::get_git_repo_root;
 use codex_core::protocol::AskForApproval;
 use codex_core::protocol::Event;
 use codex_core::protocol::EventMsg;
@@ -25,6 +24,7 @@ use codex_core::protocol::InputItem;
 use codex_core::protocol::Op;
 use codex_core::protocol::SessionSource;
 use codex_core::protocol::TaskCompleteEvent;
+use codex_core::revision_control::detect_revision_control;
 use codex_ollama::DEFAULT_OSS_MODEL;
 use codex_protocol::config_types::SandboxMode;
 use event_processor_with_human_output::EventProcessorWithHumanOutput;
@@ -239,8 +239,10 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
     let default_effort = config.model_reasoning_effort;
     let default_summary = config.model_reasoning_summary;
 
-    if !skip_git_repo_check && get_git_repo_root(&default_cwd).is_none() {
-        eprintln!("Not inside a trusted directory and --skip-git-repo-check was not specified.");
+    if !skip_git_repo_check && detect_revision_control(&default_cwd).is_none() {
+        eprintln!(
+            "Not inside a Git or Darcs repository and --skip-git-repo-check was not specified."
+        );
         std::process::exit(1);
     }
 

--- a/codex-rs/tui/src/onboarding/onboarding_screen.rs
+++ b/codex-rs/tui/src/onboarding/onboarding_screen.rs
@@ -1,6 +1,6 @@
 use codex_core::AuthManager;
 use codex_core::config::Config;
-use codex_core::git_info::get_git_repo_root;
+use codex_core::revision_control::detect_revision_control;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
 use crossterm::event::KeyEventKind;
@@ -103,8 +103,8 @@ impl OnboardingScreen {
                 auth_manager,
             }))
         }
-        let is_git_repo = get_git_repo_root(&cwd).is_some();
-        let highlighted = if is_git_repo {
+        let revision_control = detect_revision_control(&cwd);
+        let highlighted = if revision_control.is_some() {
             TrustDirectorySelection::Trust
         } else {
             // Default to not trusting the directory if it's not a git repo.
@@ -114,7 +114,7 @@ impl OnboardingScreen {
             steps.push(Step::TrustDirectory(TrustDirectoryWidget {
                 cwd,
                 codex_home,
-                is_git_repo,
+                revision_control: revision_control.clone(),
                 selection: None,
                 highlighted,
                 error: None,


### PR DESCRIPTION
## Summary
- extend the revision control module with capability metadata and a helper that resolves trust roots for Darcs checkouts
- update configuration trust checks, CLI repo gating, and onboarding widgets to use backend-agnostic detection logic
- surface the detected backend in the config summary output so the CLI and TUI report Git or Darcs contexts

## Testing
- cargo fmt
- cargo test -p codex-core revision_control
- cargo test -p codex-tui onboarding

------
https://chatgpt.com/codex/tasks/task_e_68e7ba63485c832f97aa0d7afb4c1504