### PR TITLE
docs: document darcs-aware repo requirement

### DIFF
--- a/docs/exec.md
+++ b/docs/exec.md
@@ -81,9 +81,9 @@ codex exec "Extract details of the project" --output-schema ~/schema.json
 
 Combine `--output-schema` with `-o` to only print the final JSON output. You can also pass a file path to `-o` to save the JSON output to a file.
 
-### Git repository requirement
+### Revision control requirement
 
-Codex requires a Git repository to avoid destructive changes. To disable this check, use `codex exec --skip-git-repo-check`.
+Codex requires a Git or Darcs repository to avoid destructive changes. To disable this check when operating outside a supported checkout, use `codex exec --skip-git-repo-check`.
 
 ### Resuming non-interactive sessions
 

--- a/docs/git-and-github.md
+++ b/docs/git-and-github.md
@@ -5,9 +5,9 @@ implementation so the behavior can be replicated elsewhere.
 
 ## Repository prerequisites and detection
 
-* `codex exec` refuses to run outside a Git checkout unless the caller opts out with
+* `codex exec` refuses to run outside a Git or Darcs checkout unless the caller opts out with
   `--skip-git-repo-check` to protect users from destructive edits in ad-hoc directories.【F:docs/exec.md†L86-L88】
-* `codex_core::git_info::get_git_repo_root` walks up from the configured working directory until it finds a `.git`
+* `codex_core::revision_control::git::get_git_repo_root` walks up from the configured working directory until it finds a `.git`
   directory or file, allowing the application to decide whether Git features should be enabled without shelling out to
   `git` itself.【F:codex-rs/core/src/revision_control/git.rs†L1-L34】
 * `codex_core::revision_control::detect_revision_control` provides a single entry point for identifying the


### PR DESCRIPTION
## Summary
- update the exec guide to describe the Git-or-Darcs revision control requirement
- clarify the git integration overview to reference the revision_control module helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8462f09a4832f80ecd3d7398b75a2