### PR TITLE
Rename revision control documentation

### DIFF
--- a/docs/queues/darcs.md
+++ b/docs/queues/darcs.md
@@ -1,6 +1,6 @@
 # Darcs integration backlog
 
-This queue tracks the Darcs support roadmap described in [docs/git-and-github.md](../git-and-github.md).
+This queue tracks the Darcs support roadmap described in [docs/revision-control.md](../revision-control.md).
 
 Initial scaffolding for the abstraction now lives in
 `codex_core::revision_control`, which exposes a shared detection entry point
@@ -100,10 +100,10 @@ alongside GitHub releases.
 :::
 
 ### 8. Update documentation and configuration guidance
-Document Darcs setup, configuration flags, and feature parity in `docs/git-and-github.md`, onboarding guides, and config docs.
+Document Darcs setup, configuration flags, and feature parity in `docs/revision-control.md`, onboarding guides, and config docs.
 
 :::task-stub{title="Document Darcs support across guides"}
-1. Revise `docs/git-and-github.md`, `docs/exec.md`, and onboarding docs to describe dual-backend behaviour, CLI flags for
+1. Revise `docs/revision-control.md`, `docs/exec.md`, and onboarding docs to describe dual-backend behaviour, CLI flags for
    choosing revision control, and Darcs-specific workflows.
 2. Add configuration examples (e.g., selecting Darcs as default) to `docs/config.md` and update installation instructions to
    mention the `darcs` dependency.

--- a/docs/revision-control.md
+++ b/docs/revision-control.md
@@ -1,7 +1,7 @@
-# Git and GitHub integration
+# Revision-control integrations
 
-Codex relies on Git for both runtime features and release automation. This document maps each integration point to the
-implementation so the behavior can be replicated elsewhere.
+Codex relies on revision-control backends for runtime features and release automation. This document maps each
+integration point to the implementation so the behavior can be replicated elsewhere.
 
 ## Repository prerequisites and detection
 


### PR DESCRIPTION
## Summary
- rename docs/git-and-github.md to docs/revision-control.md to reflect Darcs coverage
- update the Darcs backlog queue to point at the renamed document
- refresh the document heading to describe the broader revision-control scope

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e85fd86540832f8cdfa93f9acef8d7