### PR TITLE
Add darcs installation plan and helper script

### DIFF
--- a/docs/darcs-installation-plan.md
+++ b/docs/darcs-installation-plan.md
@@ -1,0 +1,19 @@
+# Darcs installation plan
+
+To ensure integration tests that rely on the `darcs` binary can run without being skipped, we will install the Debian package in the setup hook.
+
+## Approach
+
+1. Reuse the system package manager instead of building `darcs` from source. The Debian package is sufficient for the tests and keeps installation time short.
+2. Provide an idempotent helper script (`scripts/install_darcs.sh`) that the Codex setup environment hook can call. The script checks for an existing `darcs` binary before running `apt-get` so it can be safely re-run.
+3. Run the script from the setup hook with network access. The script escalates with `sudo` when necessary, updates the package index, and installs `darcs` with minimal dependencies.
+
+## Usage
+
+Add the following invocation to the Codex setup environment hook:
+
+```bash
+/workspace/codex/scripts/install_darcs.sh
+```
+
+This will ensure the `darcs` binary is available before the tests execute.

--- a/scripts/install_darcs.sh
+++ b/scripts/install_darcs.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v darcs >/dev/null 2>&1; then
+  echo "darcs already installed: $(command -v darcs)"
+  exit 0
+fi
+
+if [ "${EUID}" -ne 0 ]; then
+  echo "Re-running with sudo to install darcs via apt." >&2
+  exec sudo "$0" "$@"
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y --no-install-recommends darcs


### PR DESCRIPTION
## Summary
- document the approach for installing the darcs binary during environment setup
- add a reusable helper script that installs darcs via apt when needed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb09da733c832fb513667cfdeb2135