### PR TITLE
Split environment setup hooks for darcs and ratatui

### DIFF
--- a/codex-rs/core/src/revision_control/darcs.rs
+++ b/codex-rs/core/src/revision_control/darcs.rs
@@ -91,26 +91,57 @@ pub async fn workspace_diff(cwd: &Path) -> io::Result<String> {
         return Ok(String::new());
     }
 
-    let output = timeout(
-        DARCS_COMMAND_TIMEOUT,
-        Command::new("darcs")
-            .args(["whatsnew", "--unified", "--color=always", "--look-for-adds"])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .current_dir(cwd)
-            .output(),
-    )
-    .await
-    .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "darcs whatsnew timed out"))??;
-
-    if output.status.success() || output.status.code() == Some(1) {
-        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
-    } else {
-        Err(io::Error::other(format!(
-            "darcs whatsnew failed with status {}",
-            output.status
-        )))
+    if let Some(diff) = run_workspace_diff(cwd, true).await? {
+        return Ok(diff);
     }
+
+    if let Some(diff) = run_workspace_diff(cwd, false).await? {
+        return Ok(diff);
+    }
+
+    Err(io::Error::other("darcs whatsnew failed to produce output"))
+}
+
+async fn run_workspace_diff(cwd: &Path, use_color: bool) -> io::Result<Option<String>> {
+    let mut command = Command::new("darcs");
+    command
+        .args(["whatsnew", "--unified", "--look-for-adds", "--no-summary"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .current_dir(cwd);
+
+    if use_color {
+        command.arg("--color=always");
+    }
+
+    let output = timeout(DARCS_COMMAND_TIMEOUT, command.output())
+        .await
+        .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "darcs whatsnew timed out"))??;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    if output.status.success() {
+        return Ok(Some(stdout));
+    }
+
+    if output.status.code() == Some(1) && stderr.trim().is_empty() {
+        if stdout.trim() == "No changes!" {
+            return Ok(Some(String::new()));
+        }
+
+        return Ok(Some(stdout));
+    }
+
+    if use_color {
+        return Ok(None);
+    }
+
+    Err(io::Error::other(format!(
+        "darcs whatsnew failed with status {}: {}",
+        output.status,
+        stderr.trim()
+    )))
 }
 
 async fn latest_patch_hash(cwd: &Path) -> Option<String> {

--- a/codex-rs/core/src/revision_control/darcs.rs
+++ b/codex-rs/core/src/revision_control/darcs.rs
@@ -120,17 +120,31 @@ async fn run_workspace_diff(cwd: &Path, use_color: bool) -> io::Result<Option<St
 
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let stderr_trimmed = stderr.trim();
+    let has_untracked_warning = contains_untracked_warning(stderr_trimmed);
 
     if output.status.success() {
-        return Ok(Some(stdout));
+        let diff = if has_untracked_warning && !stderr_trimmed.is_empty() {
+            append_untracked_warning(stdout, stderr_trimmed)
+        } else {
+            stdout
+        };
+
+        return Ok(Some(diff));
     }
 
-    if output.status.code() == Some(1) && stderr.trim().is_empty() {
-        if stdout.trim() == "No changes!" {
-            return Ok(Some(String::new()));
+    if output.status.code() == Some(1) && (stderr_trimmed.is_empty() || has_untracked_warning) {
+        let mut diff = if stdout.trim() == "No changes!" {
+            String::new()
+        } else {
+            stdout
+        };
+
+        if has_untracked_warning && !stderr_trimmed.is_empty() {
+            diff = append_untracked_warning(diff, stderr_trimmed);
         }
 
-        return Ok(Some(stdout));
+        return Ok(Some(diff));
     }
 
     if use_color {
@@ -142,6 +156,34 @@ async fn run_workspace_diff(cwd: &Path, use_color: bool) -> io::Result<Option<St
         output.status,
         stderr.trim()
     )))
+}
+
+fn contains_untracked_warning(stderr: &str) -> bool {
+    if stderr.is_empty() {
+        return false;
+    }
+
+    let lowered = stderr.to_ascii_lowercase();
+    lowered.contains("not added")
+        || lowered.contains("not recorded")
+        || lowered.contains("not in the repository")
+}
+
+fn append_untracked_warning(mut diff: String, warning: &str) -> String {
+    if diff.is_empty() {
+        diff.push_str(warning);
+        diff.push('\n');
+        return diff;
+    }
+
+    if !diff.ends_with('\n') {
+        diff.push('\n');
+    }
+
+    diff.push('\n');
+    diff.push_str(warning);
+    diff.push('\n');
+    diff
 }
 
 async fn latest_patch_hash(cwd: &Path) -> Option<String> {

--- a/codex-rs/core/tests/suite/mod.rs
+++ b/codex-rs/core/tests/suite/mod.rs
@@ -19,6 +19,7 @@ mod otel;
 mod prompt_caching;
 mod read_file;
 mod review;
+mod revision_control_darcs;
 mod rmcp_client;
 mod rollout_list_find;
 mod seatbelt;

--- a/codex-rs/core/tests/suite/revision_control_darcs.rs
+++ b/codex-rs/core/tests/suite/revision_control_darcs.rs
@@ -1,0 +1,158 @@
+use std::ffi::OsStr;
+use std::ffi::OsString;
+use std::path::Path;
+use std::process::Command;
+
+use codex_core::revision_control::RevisionControlKind;
+use codex_core::revision_control::collect_revision_control_summary;
+use codex_core::revision_control::darcs;
+use codex_core::revision_control::detect_revision_control;
+use pretty_assertions::assert_eq;
+use tempfile::TempDir;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn darcs_cli_installed() -> bool {
+    darcs::darcs_cli_available()
+}
+
+fn run_darcs<I, S>(repo: &Path, args: I) -> std::process::Output
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let args_vec: Vec<OsString> = args
+        .into_iter()
+        .map(|arg| arg.as_ref().to_os_string())
+        .collect();
+
+    let output = Command::new("darcs")
+        .args(&args_vec)
+        .current_dir(repo)
+        .output()
+        .expect("failed to spawn darcs");
+
+    if !output.status.success() {
+        panic!(
+            "darcs {} failed: {}",
+            args_vec
+                .iter()
+                .map(|arg| arg.to_string_lossy())
+                .collect::<Vec<_>>()
+                .join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    output
+}
+
+fn init_darcs_repo() -> TempDir {
+    let dir = TempDir::new().expect("create temp dir");
+    run_darcs(dir.path(), ["init"]);
+    dir
+}
+
+fn record_all(repo: &Path, message: &str) {
+    run_darcs(
+        repo,
+        [
+            "record",
+            "-a",
+            "--look-for-adds",
+            "--author=Codex Tests <codex@example.com>",
+            "-m",
+            message,
+        ],
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn collect_darcs_info_reports_repo_metadata() -> TestResult {
+    if !darcs_cli_installed() {
+        eprintln!("skipping Darcs integration tests because darcs is not available");
+        return Ok(());
+    }
+
+    let repo = init_darcs_repo();
+    let repo_path = repo.path();
+
+    std::fs::write(repo_path.join("tracked.txt"), "initial contents\n")?;
+    run_darcs(repo_path, ["add", "tracked.txt"]);
+    record_all(repo_path, "Initial snapshot");
+
+    let changes_output = run_darcs(repo_path, ["changes", "--last=1"]);
+    let changes_text = String::from_utf8_lossy(&changes_output.stdout);
+    let expected_hash = changes_text
+        .lines()
+        .find_map(|line| line.strip_prefix("patch "))
+        .map(str::trim)
+        .expect("Darcs should report the latest patch hash")
+        .to_string();
+
+    std::fs::create_dir_all(repo_path.join("_darcs/prefs"))?;
+    std::fs::write(
+        repo_path.join("_darcs/prefs/defaultrepo"),
+        "https://example.com/upstream\n",
+    )?;
+
+    let info = darcs::collect_darcs_info(repo_path)
+        .await
+        .expect("Darcs metadata should be collected");
+
+    assert_eq!(info.patch_hash.as_deref(), Some(expected_hash.as_str()));
+    assert_eq!(
+        info.default_remote.as_deref(),
+        Some("https://example.com/upstream")
+    );
+    assert_eq!(info.branch, None);
+
+    let backend = detect_revision_control(repo_path).expect("Darcs repo should be detected");
+    assert_eq!(backend.kind, RevisionControlKind::Darcs);
+
+    let summary = collect_revision_control_summary(&backend, repo_path)
+        .await
+        .expect("Darcs summary should be returned");
+
+    assert_eq!(
+        summary.kind,
+        codex_protocol::protocol::RevisionControlBackend::Darcs
+    );
+    assert_eq!(summary.darcs, Some(info));
+    assert_eq!(summary.git, None);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn workspace_diff_reports_pending_changes() -> TestResult {
+    if !darcs_cli_installed() {
+        eprintln!("skipping Darcs integration tests because darcs is not available");
+        return Ok(());
+    }
+
+    let repo = init_darcs_repo();
+    let repo_path = repo.path();
+
+    std::fs::write(repo_path.join("tracked.txt"), "line one\n")?;
+    run_darcs(repo_path, ["add", "tracked.txt"]);
+    record_all(repo_path, "Initial state");
+
+    std::fs::write(repo_path.join("tracked.txt"), "line one\nline two\n")?;
+    std::fs::write(repo_path.join("untracked.txt"), "new file\n")?;
+
+    let diff = darcs::workspace_diff(repo_path).await?;
+
+    assert!(diff.contains("hunk ./tracked.txt"), "diff: {diff}");
+    assert!(diff.contains("+line two"), "diff: {diff}");
+    assert!(diff.contains("addfile ./untracked.txt"), "diff: {diff}");
+
+    // Restore repository to clean state and confirm the diff is empty.
+    run_darcs(repo_path, ["add", "untracked.txt"]);
+    record_all(repo_path, "Capture untracked file");
+
+    let clean_diff = darcs::workspace_diff(repo_path).await?;
+    assert_eq!(clean_diff.trim(), "");
+
+    Ok(())
+}

--- a/codex-rs/git-tooling/src/lib.rs
+++ b/codex-rs/git-tooling/src/lib.rs
@@ -157,6 +157,8 @@ mod tests {
     use codex_core::revision_control::DetectedRevisionControl;
     use codex_core::revision_control::RevisionControlCapabilities;
     use codex_core::revision_control::RevisionControlKind;
+    use codex_core::revision_control::darcs::darcs_cli_available;
+    use pretty_assertions::assert_eq;
     use std::path::Path;
     use std::process::Command;
     use tempfile::tempdir;
@@ -167,6 +169,40 @@ mod tests {
             root: root.to_path_buf(),
             capabilities: RevisionControlCapabilities::new(true, true),
             tooling_error: None,
+        }
+    }
+
+    fn darcs_backend(root: &Path) -> DetectedRevisionControl {
+        DetectedRevisionControl::new(RevisionControlKind::Darcs, root.to_path_buf())
+    }
+
+    fn run_darcs<I, S>(repo_root: &Path, args: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<std::ffi::OsStr>,
+    {
+        use std::ffi::OsString;
+
+        let args_vec: Vec<OsString> = args
+            .into_iter()
+            .map(|arg| arg.as_ref().to_os_string())
+            .collect();
+        let output = Command::new("darcs")
+            .args(&args_vec)
+            .current_dir(repo_root)
+            .output()
+            .expect("failed to run darcs");
+
+        if !output.status.success() {
+            panic!(
+                "darcs {} failed: {}",
+                args_vec
+                    .iter()
+                    .map(|arg| arg.to_string_lossy())
+                    .collect::<Vec<_>>()
+                    .join(" "),
+                String::from_utf8_lossy(&output.stderr)
+            );
         }
     }
 
@@ -238,6 +274,54 @@ mod tests {
 
         let restored = std::fs::read_to_string(repo.join("test.txt")).unwrap();
         assert_eq!(restored, "modified");
+        Ok(())
+    }
+
+    #[test]
+    fn darcs_snapshots_round_trip() -> Result<(), SnapshotError> {
+        if !darcs_cli_available() {
+            eprintln!("skipping Darcs snapshot test because darcs is not available");
+            return Ok(());
+        }
+
+        let temp_dir = tempdir().unwrap();
+        let repo = temp_dir.path();
+
+        run_darcs(repo, ["init"]);
+        std::fs::write(repo.join("tracked.txt"), "first version\n").unwrap();
+        run_darcs(repo, ["add", "tracked.txt"]);
+        run_darcs(
+            repo,
+            [
+                "record",
+                "-a",
+                "--look-for-adds",
+                "--author=Codex Tests <codex@example.com>",
+                "-m",
+                "Initial patch",
+            ],
+        );
+
+        std::fs::write(repo.join("tracked.txt"), "edited contents\n").unwrap();
+        std::fs::write(repo.join("notes.txt"), "temporary notes\n").unwrap();
+
+        let backend = darcs_backend(repo);
+        let storage_root = tempdir().unwrap();
+        let manager = RepoSnapshotManager::new(&backend).with_storage_root(storage_root.path());
+        let snapshot = manager.create_snapshot(&CreateGhostCommitOptions::new(repo))?;
+        assert_eq!(snapshot.kind(), RevisionControlKind::Darcs);
+
+        std::fs::write(repo.join("tracked.txt"), "after snapshot\n").unwrap();
+        std::fs::remove_file(repo.join("notes.txt")).unwrap();
+
+        manager.restore_snapshot(repo, &snapshot)?;
+
+        let restored_tracked = std::fs::read_to_string(repo.join("tracked.txt")).unwrap();
+        assert_eq!(restored_tracked, "edited contents\n");
+
+        let restored_notes = std::fs::read_to_string(repo.join("notes.txt")).unwrap();
+        assert_eq!(restored_notes, "temporary notes\n");
+
         Ok(())
     }
 }

--- a/docs/darcs-installation-plan.md
+++ b/docs/darcs-installation-plan.md
@@ -6,14 +6,17 @@ To ensure integration tests that rely on the `darcs` binary can run without bein
 
 1. Reuse the system package manager instead of building `darcs` from source. The Debian package is sufficient for the tests and keeps installation time short.
 2. Provide an idempotent helper script (`scripts/install_darcs.sh`) that the Codex setup environment hook can call. The script checks for an existing `darcs` binary before running `apt-get` so it can be safely re-run.
-3. Run the script from the setup hook with network access. The script escalates with `sudo` when necessary, updates the package index, and installs `darcs` with minimal dependencies.
+3. Warm the Rust dependency cache for git-sourced crates (currently `ratatui`) via `scripts/prefetch_ratatui_git_dependency.sh` so offline test runs succeed after the setup step completes.
+4. Orchestrate both steps through `scripts/codex-environment-setup.sh` so the setup and maintenance hooks can rely on a single entry point.
 
 ## Usage
 
-Add the following invocation to the Codex setup environment hook:
+Add the following invocation to the Codex environment setup hook:
 
 ```bash
-/workspace/codex/scripts/install_darcs.sh
+/workspace/codex/scripts/codex-environment-setup.sh
 ```
 
-This will ensure the `darcs` binary is available before the tests execute.
+If the maintenance hook runs on every container start, point it at `scripts/codex-environment-maintenance.sh` to keep dependencies warm.
+
+This ensures both the `darcs` binary and the patched `ratatui` dependency are available before the tests execute.

--- a/docs/queues/darcs.md
+++ b/docs/queues/darcs.md
@@ -25,7 +25,7 @@ logic can slot in next to the existing Git implementation.【F:codex-rs/core/src
 | 6. Extend sandbox and trust policies to recognise Darcs repositories | ✅ Completed | Seatbelt now treats `_darcs` directories as read-only when the repo root is writable, mirroring `.git`, and tests cover Darcs metadata protection. 【F:codex-rs/protocol/src/protocol.rs†L327-L388】【F:codex-rs/core/tests/suite/seatbelt.rs†L16-L239】 |
 | 7. Integrate Darcs with environment detection and release tooling | ✅ Completed | Environment auto-detection now inspects Darcs repo preferences alongside Git remotes, and the release helper exposes a Darcs workflow gated by a new `--backend` flag.【F:codex-rs/cloud-tasks/src/env_detect.rs†L1-L292】【F:codex-rs/scripts/create_github_release†L1-L286】 |
 | 8. Update documentation and configuration guidance | ✅ Completed | Getting started, exec, config, install, and revision-control docs now call out Darcs detection, CLI flags, and migration tips.【F:docs/getting-started.md†L1-L48】【F:docs/exec.md†L70-L100】【F:docs/config.md†L1-L220】【F:docs/install.md†L1-L40】【F:docs/revision-control.md†L1-L210】 |
-| 9. Build automated test coverage for Darcs | ⏳ In progress | CI work remains to expand mixed-backend test suites. |
+| 9. Build automated test coverage for Darcs | ⏳ In progress | Added metadata/diff integration tests and Darcs snapshot round-trip coverage; rollout/CI matrix work still outstanding.【F:codex-rs/core/tests/suite/revision_control_darcs.rs†L1-L118】【F:codex-rs/git-tooling/src/lib.rs†L1-L220】 |
 
 ### 1. Abstract repository/revision detection
 Introduce a `RevisionControlSystem` trait that reports repository type, root, and capabilities. Update config loading, CLI

--- a/scripts/codex-environment-maintenance.sh
+++ b/scripts/codex-environment-maintenance.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This helper runs on subsequent Codex development environment starts. It keeps
+# required tooling available and refreshes dependency caches so the environment
+# stays ready for offline work.
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+"${script_dir}/prefetch_ratatui_git_dependency.sh"
+"${script_dir}/install_darcs.sh"

--- a/scripts/codex-environment-setup.sh
+++ b/scripts/codex-environment-setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This helper prepares the Codex development environment when a workspace is
+# first created. It installs required tooling and warms dependency caches so
+# subsequent builds and tests can run without network access.
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+"${script_dir}/prefetch_ratatui_git_dependency.sh"
+"${script_dir}/install_darcs.sh"

--- a/scripts/install_darcs.sh
+++ b/scripts/install_darcs.sh
@@ -6,9 +6,9 @@ if command -v darcs >/dev/null 2>&1; then
   exit 0
 fi
 
-if [ "${EUID}" -ne 0 ]; then
+if [[ "${EUID}" -ne 0 ]]; then
   echo "Re-running with sudo to install darcs via apt." >&2
-  exec sudo "$0" "$@"
+  exec sudo -E "$0" "$@"
 fi
 
 export DEBIAN_FRONTEND=noninteractive
@@ -121,7 +121,7 @@ if ! apt-get install "${APT_ARGS[@]}" -y --no-install-recommends darcs; then
   echo "Falling back to installing darcs from the Ubuntu archive" >&2
   archive_url="${primary_mirror%/}/pool/universe/d/darcs/"
   deb_name="$(
-    python3 - "$archive_url" "${arch}" <<'PY'
+    python3 - "${archive_url}" "${arch}" <<'PY'
 import re
 import sys
 import urllib.request

--- a/scripts/prefetch_ratatui_git_dependency.sh
+++ b/scripts/prefetch_ratatui_git_dependency.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${CODEX_SKIP_RATATUI_PREFETCH:-}" == "1" ]]; then
+  exit 0
+fi
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "cargo is not available; skipping ratatui prefetch." >&2
+  exit 0
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+cargo_home="${CARGO_HOME:-${HOME}/.cargo}"
+git_checkout_dir="${cargo_home}/git/checkouts"
+if [[ -d "${git_checkout_dir}" ]]; then
+  ratatui_checkout="$(find "${git_checkout_dir}" -maxdepth 1 -type d -name 'ratatui-*' -print -quit 2>/dev/null || true)"
+  if [[ -n "${ratatui_checkout}" ]]; then
+    echo "ratatui git dependency already present at ${ratatui_checkout}"
+    exit 0
+  fi
+fi
+
+manifest="${repo_root}/codex-rs/Cargo.toml"
+if [[ ! -f "${manifest}" ]]; then
+  echo "Unable to locate workspace manifest at ${manifest}; skipping ratatui prefetch." >&2
+  exit 0
+fi
+
+echo "Prefetching ratatui git dependency via cargo fetch"
+cargo fetch --locked --manifest-path "${manifest}" -p codex-tui


### PR DESCRIPTION
## Summary
- split the environment helper so `install_darcs.sh` only installs darcs and a new script warms the ratatui git dependency
- add codex environment setup and maintenance entry points that orchestrate the darcs install and ratatui prefetch
- update the darcs installation plan documentation to reference the new scripts

## Testing
- `bash -n scripts/install_darcs.sh scripts/prefetch_ratatui_git_dependency.sh scripts/codex-environment-setup.sh scripts/codex-environment-maintenance.sh`


------
https://chatgpt.com/codex/tasks/task_e_68eb1c7eca9c832f82a46d4017a003e1