### PR TITLE
Fix ratatui prefetch script cargo command

### DIFF
--- a/scripts/prefetch_ratatui_git_dependency.sh
+++ b/scripts/prefetch_ratatui_git_dependency.sh
@@ -29,4 +29,4 @@ if [[ ! -f "${manifest}" ]]; then
 fi
 
 echo "Prefetching ratatui git dependency via cargo fetch"
-cargo fetch --locked --manifest-path "${manifest}" -p codex-tui
+cargo fetch --locked --manifest-path "${manifest}"


### PR DESCRIPTION
## Summary
- remove the unsupported package filter when prefetching the ratatui git dependency so cargo fetch succeeds

## Testing
- bash scripts/prefetch_ratatui_git_dependency.sh *(fails: upstream git repo responds with HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ebb5733484832f824b668b4e493131