### PR TITLE
Add Nix output hash for ratatui git dependency

### DIFF
--- a/codex-rs/default.nix
+++ b/codex-rs/default.nix
@@ -9,7 +9,12 @@ rec {
     inherit env;
     pname = "codex-rs";
     version = "0.1.0";
-    cargoLock.lockFile = ./Cargo.lock;
+    cargoLock = {
+      lockFile = ./Cargo.lock;
+      outputHashes = {
+        "ratatui-0.29.0" = "sha256-HBvT5c8GsiCxMffNjJGLmHnvG77A6cqEL+1ARurBXho=";
+      };
+    };
     doCheck = false;
     src = ./.;
     nativeBuildInputs = with pkgs; [


### PR DESCRIPTION
## Summary
- teach codex-rs's Nix definition about the vendored ratatui git dependency hash so builds no longer fail with "No hash was found" errors

## Testing
- nix develop .#codex-rs -c true *(fails in sandbox: GitHub HTTP 403 while fetching ratatui)*

------
https://chatgpt.com/codex/tasks/task_e_68eef2d4b140832fb8f32f4ff168feec