### PR TITLE
Align Nix tooling with repository toolchains

### DIFF
--- a/codex-cli/default.nix
+++ b/codex-cli/default.nix
@@ -1,0 +1,49 @@
+{ pkgs, monorepo-deps ? [], ... }:
+let
+  nodejs = if pkgs ? nodejs_22 then pkgs.nodejs_22 else pkgs.nodejs;
+  env = {
+    PNPM_HOME = "$HOME/.pnpm";
+    PATH = "$PNPM_HOME:$PATH";
+  };
+  commonPackages = monorepo-deps ++ [
+    nodejs
+  ];
+in
+rec {
+  package = pkgs.stdenvNoCC.mkDerivation {
+    pname = "codex-cli";
+    version = "0.0.0-dev";
+    src = ./.;
+    dontConfigure = true;
+    dontBuild = true;
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out"
+      cp -r . "$out/"
+      runHook postInstall
+    '';
+    meta = with pkgs.lib; {
+      description = "OpenAI Codex command-line interface wrapper";
+      homepage = "https://github.com/openai/codex";
+      license = licenses.asl20;
+    };
+  };
+
+  devShell = pkgs.mkShell {
+    inherit env;
+    name = "codex-cli-dev";
+    packages = commonPackages;
+    shellHook = ''
+      echo "Entering development shell for codex-cli"
+      mkdir -p "$PNPM_HOME"
+      export PATH="$PNPM_HOME:$PATH"
+    '';
+  };
+
+  app = {
+    type = "app";
+    program = "${pkgs.writeShellScriptBin "codex" ''
+      exec ${nodejs}/bin/node ${package}/bin/codex.js "$@"
+    ''}/bin/codex";
+  };
+}

--- a/codex-rs/default.nix
+++ b/codex-rs/default.nix
@@ -1,11 +1,20 @@
-{ pkgs, monorep-deps ? [], ... }:
+{ pkgs, monorepo-deps ? [], ... }:
 let
   env = {
     PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig:$PKG_CONFIG_PATH";
   };
+  rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+  rustPlatform = pkgs.makeRustPlatform {
+    cargo = rustToolchain;
+    rustc = rustToolchain;
+  };
+  nativeBuildInputs = with pkgs; [
+    pkg-config
+    openssl
+  ];
 in
 rec {
-  package = pkgs.rustPlatform.buildRustPackage {
+  package = rustPlatform.buildRustPackage {
     inherit env;
     pname = "codex-rs";
     version = "0.1.0";
@@ -17,10 +26,7 @@ rec {
     };
     doCheck = false;
     src = ./.;
-    nativeBuildInputs = with pkgs; [
-      pkg-config
-      openssl
-    ];
+    nativeBuildInputs = nativeBuildInputs;
     meta = with pkgs.lib; {
       description = "OpenAI Codex command‑line interface rust implementation";
       license = licenses.asl20;
@@ -30,14 +36,12 @@ rec {
   devShell = pkgs.mkShell {
     inherit env;
     name = "codex-rs-dev";
-    packages = monorep-deps ++ [
-      pkgs.cargo
-      package
+    packages = monorepo-deps ++ nativeBuildInputs ++ [
+      rustToolchain
     ];
     shellHook = ''
       echo "Entering development shell for codex-rs"
       alias codex="cd ${package.src}/tui; cargo run; cd -"
-      ${pkgs.rustPlatform.cargoSetupHook}
     '';
   };
   app = {

--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746844454,
-        "narHash": "sha256-GcUWDQUDRYrD34ol90KGUpjbVcOfUNbv0s955jPecko=",
+        "lastModified": 1760495781,
+        "narHash": "sha256-3OGPAQNJswy6L4VJyX3U9/z7fwgPFvK6zQtB2NHBV0Y=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "be092436d4c0c303b654e4007453b69c0e33009e",
+        "rev": "11e0852a2aa3a65955db5824262d76933750e299",
         "type": "github"
       },
       "original": {

--- a/nixos-build.sh
+++ b/nixos-build.sh
@@ -15,7 +15,7 @@ if ! command -v nix >/dev/null 2>&1; then
 fi
 
 echo "==> Building Rust workspace (codex-rs)"
-nix develop .#codex-rs --command cargo build --workspace --locked
+nix develop .#codex-rs --command bash -c 'cd codex-rs && cargo build --workspace --locked'
 
 echo
 


### PR DESCRIPTION
## Summary
- pin the codex-rs flake to the repository's rust-toolchain so nix builds use rustc 1.90
- add a codex-cli nix definition that provides a node+pnpm dev shell and simple package wrapper
- update nixos-build.sh to run cargo inside codex-rs and reuse the new dev shell targets

## Testing
- `nix develop .#codex-rs --command rustc --version`
- `nix develop .#codex-cli --command node --version`
- `./nixos-build.sh` *(interrupted after confirming the Rust build now starts with the pinned toolchain to avoid a very long compile)*

------
https://chatgpt.com/codex/tasks/task_e_68f056ce844c832f88d133eb13c67595