### PR TITLE
Align pnpm pin and add drift detection tooling

### DIFF
--- a/docs/build-test-diagnosis.md
+++ b/docs/build-test-diagnosis.md
@@ -5,16 +5,17 @@
 - The monorepo pins pnpm 10.8.1 via the `packageManager` field in `package.json`, so pnpm attempts to self-upgrade by repeatedly executing `pnpm add pnpm@10.8.1`.
 - Each self-upgrade attempt recurses and spawns additional Node processes, leading to runaway process trees and eventual `ERANGE: result too large, uv_cwd` errors observed in the build script log.
 
-**Planned fix**
-- Update the Nix flake (`flake.nix`) to depend on pnpm 10.8.1 (or newer) so the dev shell matches the repository's pinned package manager version.
-- After bumping pnpm, re-run `./nixos-build.sh` to confirm that `pnpm install --frozen-lockfile` succeeds without triggering self-upgrade loops.
-- Consider adding a CI assertion that `pnpm -v` matches the pinned version to catch future drift.
+**Fix**
+- `flake.nix` now ships a custom `pnpm` derivation whose version matches the repository pin (currently 10.8.1). Invoking `nix develop` therefore exposes the correct CLI without relying on self-upgrades.
+- `nixos-build.sh` performs an early guard via `scripts/check-pnpm-version.sh`, ensuring the in-shell pnpm binary matches the version declared in `package.json` before any install or build steps run. The script also validates the Rust toolchain with `scripts/check-rust-version.sh`, catching mismatched `rustc`/`cargo` builds before the workspace build starts.
+- Added helper scripts for refreshing pins: `./scripts/set-pnpm-version.sh <pnpm-version>` rewrites the pnpm derivation and package metadata, while `./scripts/set-rust-version.sh <rust-version>` updates `codex-rs/rust-toolchain.toml` to keep Nix shells and `rustup`-managed toolchains aligned.
+- If either check fails, rerun the corresponding setter script with the desired version and re-run `./nixos-build.sh`.
 
 ## Landlock sandbox errors during `nixos-test.sh`
 - The failing tests (`python_multiprocessing_lock_works_under_sandbox` and `sandbox_distinguishes_command_and_policy_cwds`) rely on Linux Landlock enforcement.
 - The container kernel lacks Landlock support (`/sys/kernel/security/landlock/features` is absent and `CONFIG_SECURITY_LANDLOCK` is disabled in `/proc/config.gz`), so applying the ruleset returns `RulesetStatus::NotEnforced` and `codex-linux-sandbox` emits `SandboxErr::LandlockRestrict`.
 
-**Planned fix**
+**Next steps**
 - Teach the Linux sandbox helper (and the affected tests) to detect when Landlock support is unavailable and skip or downgrade gracefully instead of treating it as a hard failure.
 - Add documentation noting the kernel requirements (Landlock enabled) for running the sandbox test suite locally.
 - Optionally extend CI to run Landlock-dependent tests only on builders with the feature enabled, while skipping them elsewhere.

--- a/flake.nix
+++ b/flake.nix
@@ -16,13 +16,43 @@
         pkgs = import nixpkgs {
           inherit system;
         };
+        pnpmVersion = "10.8.1";
+        pnpmPinned = pkgs.stdenvNoCC.mkDerivation {
+          pname = "pnpm";
+          version = pnpmVersion;
+          src = pkgs.fetchurl {
+            url = "https://registry.npmjs.org/pnpm/-/pnpm-${pnpmVersion}.tgz";
+            sha256 = "1iya8w749nz94swvggfyd9mz245r82b5rd56xi4w60ngcnyfpcnq";
+          };
+          dontConfigure = true;
+          dontBuild = true;
+          unpackPhase = ''
+            runHook preUnpack
+            tar -xzf "$src"
+            runHook postUnpack
+          '';
+          installPhase = ''
+            runHook preInstall
+            mkdir -p "$out/lib/node_modules" "$out/bin"
+            cp -r package "$out/lib/node_modules/pnpm"
+            ln -s "$out/lib/node_modules/pnpm/bin/pnpm.cjs" "$out/bin/pnpm"
+            ln -s "$out/lib/node_modules/pnpm/bin/pnpx.cjs" "$out/bin/pnpx"
+            runHook postInstall
+          '';
+          meta = with pkgs.lib; {
+            description = "Fast, disk space efficient package manager";
+            homepage = "https://pnpm.io/";
+            license = licenses.mit;
+            mainProgram = "pnpm";
+          };
+        };
         pkgsWithRust = import nixpkgs {
           inherit system;
           overlays = [ rust-overlay.overlays.default ];
         };
         monorepo-deps = with pkgs; [
           # for precommit hook
-          pnpm
+          pnpmPinned
           husky
           darcs
         ];

--- a/nixos-build.sh
+++ b/nixos-build.sh
@@ -14,6 +14,10 @@ if ! command -v nix >/dev/null 2>&1; then
   exit 1
 fi
 
+echo "==> Checking pinned tool versions"
+nix develop .#codex-cli --command bash -c './scripts/check-pnpm-version.sh'
+nix develop .#codex-rs --command bash -c './scripts/check-rust-version.sh'
+
 echo "==> Building Rust workspace (codex-rs)"
 nix develop .#codex-rs --command bash -c 'cd codex-rs && cargo build --workspace --locked'
 

--- a/scripts/check-pnpm-version.sh
+++ b/scripts/check-pnpm-version.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve repository root even when invoked through symlinks.
+if ROOT=$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null); then
+  cd "$ROOT"
+else
+  SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd -P)
+  cd "$SCRIPT_DIR/.."
+fi
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "check-pnpm-version: pnpm not found in PATH" >&2
+  exit 1
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "check-pnpm-version: node not found in PATH" >&2
+  exit 1
+fi
+
+PINNED_VERSION=$(node -p "require('./package.json').packageManager.split('@')[1]")
+CURRENT_VERSION=$(pnpm --version)
+
+if [[ "$CURRENT_VERSION" != "$PINNED_VERSION" ]]; then
+  cat <<MSG >&2
+Detected pnpm version drift.
+  pinned:  $PINNED_VERSION
+  current: $CURRENT_VERSION
+Please refresh the pnpm pin to realign the development shell.
+MSG
+  exit 1
+fi
+
+printf 'pnpm %s matches repository pin.\n' "$CURRENT_VERSION"

--- a/scripts/check-rust-version.sh
+++ b/scripts/check-rust-version.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve repository root even when invoked through symlinks.
+if ROOT=$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null); then
+  cd "$ROOT"
+else
+  SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd -P)
+  cd "$SCRIPT_DIR/.."
+fi
+
+if ! command -v rustc >/dev/null 2>&1; then
+  echo "check-rust-version: rustc not found in PATH" >&2
+  exit 1
+fi
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "check-rust-version: cargo not found in PATH" >&2
+  exit 1
+fi
+
+PINNED_VERSION=$(sed -n 's/^channel = "\(.*\)"/\1/p' codex-rs/rust-toolchain.toml | head -n1)
+if [[ -z "$PINNED_VERSION" ]]; then
+  echo "check-rust-version: unable to determine pinned version from codex-rs/rust-toolchain.toml" >&2
+  exit 1
+fi
+
+CURRENT_RUSTC=$(rustc --version | awk '{print $2}')
+CURRENT_CARGO=$(cargo --version | awk '{print $2}')
+
+if [[ "$CURRENT_RUSTC" != "$PINNED_VERSION" || "$CURRENT_CARGO" != "$PINNED_VERSION" ]]; then
+  cat <<MSG >&2
+Detected Rust toolchain version drift.
+  pinned:  $PINNED_VERSION
+  rustc:   $CURRENT_RUSTC
+  cargo:   $CURRENT_CARGO
+Please refresh the Rust pin in codex-rs/rust-toolchain.toml and rebuild the development shell.
+MSG
+  exit 1
+fi
+
+printf 'rustc %s / cargo %s match repository pin.\n' "$CURRENT_RUSTC" "$CURRENT_CARGO"

--- a/scripts/set-pnpm-version.sh
+++ b/scripts/set-pnpm-version.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: $0 <version>
+
+Updates the pnpm version pin across the repository so the Nix dev shell and
+package.json stay in sync.
+USAGE
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -ne 1 ]]; then
+  usage >&2
+  exit 1
+fi
+
+VERSION="$1"
+TARBALL_URL="https://registry.npmjs.org/pnpm/-/pnpm-${VERSION}.tgz"
+
+for tool in nix-prefetch-url perl node; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "set-pnpm-version: required tool '$tool' not found in PATH" >&2
+    exit 1
+  fi
+done
+
+if ROOT=$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null); then
+  cd "$ROOT"
+else
+  SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd -P)
+  cd "$SCRIPT_DIR/.."
+fi
+
+echo "Fetching pnpm ${VERSION} tarball hash..." >&2
+SHA=$(nix-prefetch-url "$TARBALL_URL" | tail -n1)
+
+echo "Updating flake.nix..." >&2
+perl -0pi -e "s/pnpmVersion = \"[^\"]+\";/pnpmVersion = \"${VERSION}\";/" flake.nix
+perl -0pi -e "s#sha256 = \"[^\"]+\";#sha256 = \"${SHA}\";#" flake.nix
+
+echo "Updating package.json..." >&2
+VERSION_ENV="$VERSION" node <<'NODE'
+const fs = require('fs');
+const path = require('path');
+const version = process.env.VERSION_ENV;
+const pkgPath = path.join(process.cwd(), 'package.json');
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+pkg.packageManager = `pnpm@${version}`;
+fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+NODE
+
+echo "Pinned pnpm ${VERSION} (sha256 ${SHA})." >&2

--- a/scripts/set-rust-version.sh
+++ b/scripts/set-rust-version.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: $0 <version>
+
+Updates the Rust toolchain pin in codex-rs/rust-toolchain.toml to the provided
+version (for example, 1.90.0).
+USAGE
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -ne 1 ]]; then
+  usage >&2
+  exit 1
+fi
+
+VERSION="$1"
+
+if ROOT=$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null); then
+  cd "$ROOT"
+else
+  SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd -P)
+  cd "$SCRIPT_DIR/.."
+fi
+
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ || "$VERSION" =~ ^(stable|beta|nightly)(-[0-9]{4}-[0-9]{2}-[0-9]{2})?$ ]]; then
+  cat <<MSG >&2
+set-rust-version: unexpected version format '$VERSION'.
+Provide a full Rust release (e.g. 1.90.0) or toolchain channel (stable/beta/nightly).
+MSG
+  exit 1
+fi
+
+perl -0pi -e "s/channel = \"[^\"]+\"/channel = \"${VERSION}\"/" codex-rs/rust-toolchain.toml
+
+echo "Pinned Rust toolchain channel ${VERSION}." >&2
+echo "Run 'nix develop .#codex-rs' to refresh the shell with the new toolchain." >&2


### PR DESCRIPTION
## Summary
- package pnpm 10.8.1 directly in the flake and reuse it across development shells
- add pinned-version checks for pnpm and the Rust toolchain together with helper scripts for verifying and updating both
- document the fixes and refresh workflow in docs/build-test-diagnosis.md

## Testing
- nix develop .#codex-cli --command bash -c './scripts/check-pnpm-version.sh'
- nix develop .#codex-rs --command bash -c './scripts/check-rust-version.sh'


------
https://chatgpt.com/codex/tasks/task_e_68f0efb3bd94832f9e4f1627bab6e30e