### PR TITLE
Make Darcs snapshot type public

### DIFF
--- a/codex-rs/git-tooling/src/darcs_snapshots.rs
+++ b/codex-rs/git-tooling/src/darcs_snapshots.rs
@@ -15,7 +15,7 @@ use crate::errors::DarcsSnapshotError;
 use crate::errors::SnapshotError;
 
 #[derive(Clone)]
-pub(crate) struct DarcsSnapshot {
+pub struct DarcsSnapshot {
     id: String,
     relative_path: Option<PathBuf>,
     storage: Arc<TempDir>,


### PR DESCRIPTION
## Summary
- make the Darcs snapshot struct public so the `Snapshot::Darcs` variant no longer exposes a more-private type

## Testing
- `cargo test -p codex-git-tooling` *(fails: darcs CLI reports unsupported options in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f19553dce0832f9085f099cb7eab3a