### PR TITLE
Add documentation for Darcs testing plan

### DIFF
--- a/docs/darcs-testing-plan.md
+++ b/docs/darcs-testing-plan.md
@@ -1,0 +1,141 @@
+# Comprehensive Darcs testing plan
+
+This document captures the end-to-end verification plan for the Darcs support
+work that landed on the `trbarbour/darcs_support` branch. It enumerates the
+objectives, automated coverage, and manual validation needed to ensure Darcs
+repositories behave on par with Git across the Codex product surface.
+
+## Objectives
+
+- Validate Darcs repositories are detected, warn when the CLI is missing, and
+  feed metadata/diffs through the new backend so the UI and rollouts behave like
+  Git workspaces.
+- Confirm Codex’s onboarding, snapshots/undo flow, review prompts, rollout
+  metadata, and CLI gating all adapt to Darcs repositories.
+- Exercise CI/tooling paths that install Darcs, ensure tests skip gracefully
+  when the CLI is unavailable, and verify documentation/release tooling covers
+  Darcs workflows.
+
+## Environment & tooling setup
+
+- Install the `darcs` binary before running tests or manual checks via
+  `scripts/install_darcs.sh` or `just install`, both of which fall back across
+  package managers.
+- Capture baseline `darcs --version` output and record PATH manipulations used
+  for negative tests.
+- Prepare throwaway Darcs repos (`darcs init`) with tracked/untracked files for
+  functional scenarios.
+
+## Automated regression suite
+
+1. **Core Darcs integration tests** – `cargo test -p codex-core
+   revision_control_darcs` to cover metadata collection, workspace diffs, and
+   rollout persistence in real Darcs repos (skips automatically if the CLI is
+   absent).
+2. **Initial guidance regression** – `cargo test -p codex-core
+   darcs_repositories_emit_initial_guidance` to ensure user guidance is injected
+   into new sessions.
+3. **Seatbelt permissions (macOS)** – On a macOS runner, `cargo test -p
+   codex-core seatbelt` to verify `_darcs` directories become read-only when the
+   repo root is writable.
+4. **Snapshot manager compilation/tests** – `cargo test -p codex-git-tooling`
+   to exercise Darcs snapshot code paths alongside Git ghosts.
+5. **Cloud tasks** – `cargo test -p codex-cloud-tasks` (and add targeted cases if
+   missing) to confirm Darcs remotes are parsed from `_darcs/prefs/repos`/`darcs
+   show repo`.
+6. **Full workspace sanity** – `cargo test --workspace --all-features` with
+   Darcs installed to smoke-test unrelated crates for regressions.
+
+## Manual functional verification
+
+### Repository detection & onboarding
+
+- Start Codex inside a Darcs repo; confirm onboarding/trust steps flag the repo,
+  highlight Darcs-specific messaging, and surface tooling errors if the CLI is
+  missing.
+- Launch a new session and verify the initial context message advising the
+  Darcs CLI appears exactly once and includes the CLI warning when PATH lacks
+  `darcs`.
+
+### Diff & metadata plumbing
+
+- From the TUI `/diff` view, confirm it invokes `darcs::workspace_diff`,
+  includes untracked additions, and gracefully handles empty diffs; cross-check
+  against `darcs whatsnew --unified --look-for-adds`.
+- Trigger rollout generation (e.g., non-interactive `codex exec`) and inspect
+  JSON lines to verify Darcs metadata (patch hash, remote) is persisted in
+  session meta entries.
+
+### Snapshots & undo
+
+- With a Darcs repo, send a user message to capture a snapshot; then modify
+  files and invoke undo to ensure `RepoSnapshotManager` restores the working tree
+  and surfaces errors when the CLI is absent.
+- Validate snapshot storage under `codex_home/tmp/snapshots` is cleaned up and
+  respects scoped restores.
+
+### Review & UI flows
+
+- Open the review popup in a Darcs repo to confirm Darcs-specific options
+  (“Review pending patches”, tailored workspace prompt) appear and trigger the
+  correct prompts/actions.
+- Verify `/review` commands respect Darcs context and gather pending patch info
+  via CLI.
+
+### Exec & trust gating
+
+- Run `codex exec ...` outside any repo and within a Darcs repo to confirm the
+  CLI enforces the repo requirement unless `--skip-git-repo-check` is passed.
+- Exercise trust decisions to ensure Darcs roots become eligible for persistent
+  trust storage.
+
+### Sandbox & filesystem protection
+
+- On macOS, manually probe Seatbelt policies (or rely on tests) to ensure
+  `_darcs` contents are blocked when only the repo root is writable.
+- On other platforms, spot-check container policies so Darcs metadata isn’t
+  mutated unintentionally.
+
+### Environment detection & releases
+
+- Populate `_darcs/prefs/repos` with multiple remotes and confirm environment
+  discovery (e.g., via any CLI surfaces using `list_environments`) reports Darcs
+  origins.
+- In a Darcs repo, run `python codex-rs/scripts/create_github_release --backend
+  darcs --dry-run` to ensure tagging/push steps call the Darcs CLI and error
+  messages are user-friendly when tooling is missing.
+
+## Negative / skip scenarios
+
+- Temporarily hide `darcs` from PATH and verify detection returns a tooling
+  error, onboarding displays the warning, snapshots disable themselves with
+  actionable hints, and integration tests skip with a message rather than
+  failing.
+- Run release tooling and environment detection without Darcs installed to
+  confirm graceful failures.
+
+## Cross-platform & CI validation
+
+- Ensure GitHub Actions runners install Darcs successfully or log skip warnings;
+  replicate locally by invoking the workflow steps or `just install` on
+  macOS/Linux/Windows shells.
+- Smoke-test Darcs operations on Windows (PowerShell) since the release script
+  and installers cover that platform.
+
+## Documentation & support checks
+
+- Review updated docs (getting started, exec, revision control) to confirm they
+  match observed behavior (e.g., onboarding warnings, required CLI) and link to
+  installation guidance.
+- Verify `docs/queues/darcs.md` roadmap items marked as complete align with the
+  implemented/tested features.
+
+## Observability
+
+- Capture logs for Darcs CLI invocations and warning messages (from tracing
+  output) to aid debugging if commands time out or fail.
+
+## Testing status
+
+- ⚠️ Tests not run (QA planning only).
+

--- a/docs/queues/darcs.md
+++ b/docs/queues/darcs.md
@@ -26,6 +26,7 @@ logic can slot in next to the existing Git implementation.【F:codex-rs/core/src
 | 7. Integrate Darcs with environment detection and release tooling | ✅ Completed | Environment auto-detection now inspects Darcs repo preferences alongside Git remotes, and the release helper exposes a Darcs workflow gated by a new `--backend` flag.【F:codex-rs/cloud-tasks/src/env_detect.rs†L1-L292】【F:codex-rs/scripts/create_github_release†L1-L286】 |
 | 8. Update documentation and configuration guidance | ✅ Completed | Getting started, exec, config, install, and revision-control docs now call out Darcs detection, CLI flags, and migration tips.【F:docs/getting-started.md†L1-L48】【F:docs/exec.md†L70-L100】【F:docs/config.md†L1-L220】【F:docs/install.md†L1-L40】【F:docs/revision-control.md†L1-L210】 |
 | 9. Build automated test coverage for Darcs | ✅ Completed | Added metadata/diff integration tests, Darcs snapshot round-trip coverage, ensured rollouts persist Darcs metadata, and taught CI/just workflows to install Darcs when available while skipping Darcs suites when the CLI is missing.【F:codex-rs/core/tests/suite/revision_control_darcs.rs†L1-L220】【F:codex-rs/git-tooling/src/lib.rs†L1-L220】【F:.github/workflows/rust-ci.yml†L147-L186】【F:.github/workflows/rust-release.yml†L81-L120】【F:codex-rs/justfile†L34-L60】 |
+| 10. Execute comprehensive Darcs testing plan | 🟡 Planned | Run the manual and automated checks outlined in [docs/darcs-testing-plan.md](../darcs-testing-plan.md) to validate the shipped Darcs integration end-to-end. |
 
 ### 1. Abstract repository/revision detection
 Introduce a `RevisionControlSystem` trait that reports repository type, root, and capabilities. Update config loading, CLI
@@ -140,4 +141,14 @@ Extend unit and integration tests to exercise both Git and Darcs backends, with 
    and Darcs.
 3. Update CI scripts/Justfile to install Darcs where possible and skip Darcs suites when the binary is missing, documenting the
    expected behaviour.
+:::
+
+### 10. Execute comprehensive Darcs testing plan
+Carry out the verification steps described in [docs/darcs-testing-plan.md](../darcs-testing-plan.md) to ensure no regressions slip through.
+
+:::task-stub{title="Run through the comprehensive Darcs testing plan"}
+1. Follow the environment and tooling setup prerequisites from `docs/darcs-testing-plan.md`, confirming `darcs` availability and preparing sample repositories.
+2. Execute each automated test suite listed in the plan, recording outcomes and filing bugs for any failures or missing coverage.
+3. Perform the manual verification scenarios (UI, rollouts, snapshots, release tooling), capturing evidence/screenshots and updating this queue entry with findings.
+4. Validate negative/skip scenarios and cross-platform expectations, ensuring documentation updates or follow-up issues are created where behaviour diverges from the plan.
 :::


### PR DESCRIPTION
## Summary
- document the comprehensive Darcs verification strategy in docs/darcs-testing-plan.md
- add a tracked queue item and task stub so the testing effort can be scheduled and executed

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f4e6087154832fa55375f201e85189