### PR TITLE
Adjust Darcs snapshot validation and record testing progress

### DIFF
--- a/codex-rs/git-tooling/src/darcs_snapshots.rs
+++ b/codex-rs/git-tooling/src/darcs_snapshots.rs
@@ -73,7 +73,7 @@ pub(crate) fn create_snapshot(
     }
 
     let relative = ensure_scope_within_repo(repo_root, scope)?;
-    run_darcs_record_dry_run(repo_root)?;
+    verify_darcs_repository(repo_root)?;
 
     std::fs::create_dir_all(storage_root).map_err(|source| {
         SnapshotError::from(DarcsSnapshotError::StoragePath {
@@ -150,20 +150,8 @@ fn non_empty_path(path: &Path) -> Option<PathBuf> {
     }
 }
 
-fn run_darcs_record_dry_run(repo_root: &Path) -> Result<(), DarcsSnapshotError> {
-    run_darcs_for_status(
-        repo_root,
-        [
-            "record",
-            "--dry-run",
-            "--all",
-            "--look-for-adds",
-            "--patch",
-            "codex-snapshot",
-            "--author",
-            "Codex Snapshot <snapshot@codex.local>",
-        ],
-    )
+fn verify_darcs_repository(repo_root: &Path) -> Result<(), DarcsSnapshotError> {
+    run_darcs_for_status(repo_root, ["show", "repo"])
 }
 
 fn run_darcs_for_status<I, S>(repo_root: &Path, args: I) -> Result<(), DarcsSnapshotError>
@@ -239,7 +227,7 @@ fn should_include_entry(entry: &DirEntry, repo_root: &Path) -> bool {
         Ok(relative) => relative
             .components()
             .next()
-            .map_or(true, |component| component.as_os_str() != "_darcs"),
+            .is_none_or(|component| component.as_os_str() != "_darcs"),
         Err(_) => true,
     }
 }

--- a/codex-rs/git-tooling/src/lib.rs
+++ b/codex-rs/git-tooling/src/lib.rs
@@ -208,6 +208,11 @@ mod tests {
 
     #[test]
     fn manager_reports_missing_tool_for_darcs_without_cli() {
+        if darcs_cli_available() {
+            eprintln!("skipping missing Darcs CLI test because the darcs binary is available");
+            return;
+        }
+
         struct Dummy;
 
         impl RevisionControlSystem for Dummy {

--- a/docs/darcs-testing-plan.md
+++ b/docs/darcs-testing-plan.md
@@ -137,5 +137,9 @@ repositories behave on par with Git across the Codex product surface.
 
 ## Testing status
 
-- ⚠️ Tests not run (QA planning only).
+- ✅ `cargo test -p codex-core revision_control_darcs`
+- ✅ `cargo test -p codex-core darcs_repositories_emit_initial_guidance`
+- ✅ `cargo test -p codex-git-tooling`
+- ✅ `cargo test -p codex-cloud-tasks`
+- ⚠️ Manual functional verification, workspace-wide test suite, and cross-platform checks remain outstanding.
 

--- a/docs/queues/darcs.md
+++ b/docs/queues/darcs.md
@@ -26,7 +26,7 @@ logic can slot in next to the existing Git implementation.【F:codex-rs/core/src
 | 7. Integrate Darcs with environment detection and release tooling | ✅ Completed | Environment auto-detection now inspects Darcs repo preferences alongside Git remotes, and the release helper exposes a Darcs workflow gated by a new `--backend` flag.【F:codex-rs/cloud-tasks/src/env_detect.rs†L1-L292】【F:codex-rs/scripts/create_github_release†L1-L286】 |
 | 8. Update documentation and configuration guidance | ✅ Completed | Getting started, exec, config, install, and revision-control docs now call out Darcs detection, CLI flags, and migration tips.【F:docs/getting-started.md†L1-L48】【F:docs/exec.md†L70-L100】【F:docs/config.md†L1-L220】【F:docs/install.md†L1-L40】【F:docs/revision-control.md†L1-L210】 |
 | 9. Build automated test coverage for Darcs | ✅ Completed | Added metadata/diff integration tests, Darcs snapshot round-trip coverage, ensured rollouts persist Darcs metadata, and taught CI/just workflows to install Darcs when available while skipping Darcs suites when the CLI is missing.【F:codex-rs/core/tests/suite/revision_control_darcs.rs†L1-L220】【F:codex-rs/git-tooling/src/lib.rs†L1-L220】【F:.github/workflows/rust-ci.yml†L147-L186】【F:.github/workflows/rust-release.yml†L81-L120】【F:codex-rs/justfile†L34-L60】 |
-| 10. Execute comprehensive Darcs testing plan | 🟡 Planned | Run the manual and automated checks outlined in [docs/darcs-testing-plan.md](../darcs-testing-plan.md) to validate the shipped Darcs integration end-to-end. |
+| 10. Execute comprehensive Darcs testing plan | 🟡 In Progress | Automated regression suite executed with Darcs 2.18.4; manual UI/exec/release validation still outstanding.【F:docs/darcs-testing-plan.md†L1-L160】 |
 
 ### 1. Abstract repository/revision detection
 Introduce a `RevisionControlSystem` trait that reports repository type, root, and capabilities. Update config loading, CLI
@@ -152,3 +152,8 @@ Carry out the verification steps described in [docs/darcs-testing-plan.md](../da
 3. Perform the manual verification scenarios (UI, rollouts, snapshots, release tooling), capturing evidence/screenshots and updating this queue entry with findings.
 4. Validate negative/skip scenarios and cross-platform expectations, ensuring documentation updates or follow-up issues are created where behaviour diverges from the plan.
 :::
+
+#### Progress
+
+- ✅ Automated regression tests covering Darcs metadata, guidance, snapshots, and cloud tasks succeed with `darcs` 2.18.4 installed.【263e8d†L1-L27】【90eca2†L1-L9】【7ae0b3†L1-L15】【8a2167†L1-L25】【7aa85d†L1-L13】【62df51†L1-L5】
+- ⚠️ Manual functional verification (TUI flows, exec/trust, release tooling, negative PATH scenarios, cross-platform checks) still needs to be performed.


### PR DESCRIPTION
## Summary
- use `darcs show repo` to validate repositories during snapshot creation and avoid invoking unsupported record flags
- skip the missing Darcs CLI unit test when the binary is present
- document the executed Darcs regression suites and queue status updates

## Testing
- cargo test -p codex-core revision_control_darcs
- cargo test -p codex-core darcs_repositories_emit_initial_guidance
- cargo test -p codex-git-tooling
- cargo test -p codex-cloud-tasks


------
https://chatgpt.com/codex/tasks/task_e_68f4eff1cbfc832f80412a68bf6412de