### PR TITLE
Document workspace test failure in Darcs plan

### DIFF
--- a/docs/darcs-testing-plan.md
+++ b/docs/darcs-testing-plan.md
@@ -141,5 +141,5 @@ repositories behave on par with Git across the Codex product surface.
 - ✅ `cargo test -p codex-core darcs_repositories_emit_initial_guidance`
 - ✅ `cargo test -p codex-git-tooling`
 - ✅ `cargo test -p codex-cloud-tasks`
-- ⚠️ Manual functional verification, workspace-wide test suite, and cross-platform checks remain outstanding.
+- ⚠️ `cargo test --workspace --all-features` fails in this sandbox because the Landlock-backed `codex-exec` tests cannot initialize the kernel sandbox (`Sandbox(LandlockRestrict)`); manual functional verification and cross-platform checks remain outstanding.【7bdde7†L1-L19】
 

--- a/docs/queues/darcs.md
+++ b/docs/queues/darcs.md
@@ -157,3 +157,4 @@ Carry out the verification steps described in [docs/darcs-testing-plan.md](../da
 
 - ✅ Automated regression tests covering Darcs metadata, guidance, snapshots, and cloud tasks succeed with `darcs` 2.18.4 installed.【263e8d†L1-L27】【90eca2†L1-L9】【7ae0b3†L1-L15】【8a2167†L1-L25】【7aa85d†L1-L13】【62df51†L1-L5】
 - ⚠️ Manual functional verification (TUI flows, exec/trust, release tooling, negative PATH scenarios, cross-platform checks) still needs to be performed.
+- ⚠️ `cargo test --workspace --all-features` currently fails in this sandbox because the Landlock-backed `codex-exec` tests error with `Sandbox(LandlockRestrict)`; reruns require a host with Landlock enabled.【7bdde7†L1-L19】


### PR DESCRIPTION
## Summary
- note that `cargo test --workspace --all-features` currently fails in the sandbox because Landlock-backed codex-exec tests cannot initialize the kernel sandbox
- mirror the warning in the Darcs integration queue so the backlog reflects the limitation

## Testing
- `cargo test --workspace --all-features` *(fails: codex-exec sandbox tests require Landlock)*

------
https://chatgpt.com/codex/tasks/task_e_68f4fa99713c832f8e7f1e23c01129e0