### PR TITLE
Enable nix-command for nixos-test.sh

### DIFF
--- a/nixos-test.sh
+++ b/nixos-test.sh
@@ -14,8 +14,10 @@ if ! command -v nix >/dev/null 2>&1; then
   exit 1
 fi
 
+NIX_CMD=(nix --extra-experimental-features "nix-command flakes")
+
 echo "==> Running Rust tests (workspace, all features)"
-nix develop .#codex-rs --command bash -c '
+"${NIX_CMD[@]}" develop .#codex-rs --command bash -c '
   set -euo pipefail
   cd codex-rs
   cargo test --workspace --all-features
@@ -24,7 +26,7 @@ nix develop .#codex-rs --command bash -c '
 echo
 
 echo "==> Building Codex CLI binary for SDK tests"
-nix develop .#codex-rs --command bash -c '
+"${NIX_CMD[@]}" develop .#codex-rs --command bash -c '
   set -euo pipefail
   cd codex-rs
   cargo build -p codex-cli
@@ -33,7 +35,7 @@ nix develop .#codex-rs --command bash -c '
 echo
 
 echo "==> Running TypeScript SDK tests"
-nix develop .#codex-cli --command bash -c '
+"${NIX_CMD[@]}" develop .#codex-cli --command bash -c '
   set -euo pipefail
   cd sdk/typescript
   pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- ensure nix develop invocations enable the nix-command and flakes experimental features
- reuse a shared nix command wrapper for all nix develop calls in nixos-test.sh

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f6e8e1b524832fa1ede9c2aacd2f62