### PR TITLE
Fix PNPM_HOME path expansion in Nix shell

### DIFF
--- a/codex-cli/default.nix
+++ b/codex-cli/default.nix
@@ -1,9 +1,13 @@
 { pkgs, monorepo-deps ? [], ... }:
 let
   nodejs = if pkgs ? nodejs_22 then pkgs.nodejs_22 else pkgs.nodejs;
+  pnpmHome =
+    let
+      home = builtins.getEnv "HOME";
+    in
+    if home == "" then throw "HOME environment variable not set" else "${home}/.pnpm";
   env = {
-    PNPM_HOME = "$HOME/.pnpm";
-    PATH = "$PNPM_HOME:$PATH";
+    PNPM_HOME = pnpmHome;
   };
   commonPackages = monorepo-deps ++ [
     nodejs


### PR DESCRIPTION
## Summary
- compute PNPM_HOME using the actual HOME directory when building the codex-cli dev shell
- avoid exporting a PATH value containing a literal $PATH so pnpm uses an absolute location

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f787ed9148832fa0860a30635032f7