### PR TITLE
Make exec shell path detection portable

### DIFF
--- a/codex-cli/scripts/build_container.sh
+++ b/codex-cli/scripts/build_container.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/codex-cli/scripts/init_firewall.sh
+++ b/codex-cli/scripts/init_firewall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail  # Exit on error, undefined vars, and pipeline failures
 IFS=$'\n\t'       # Stricter word splitting
 

--- a/codex-cli/scripts/run_in_container.sh
+++ b/codex-cli/scripts/run_in_container.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Usage:

--- a/codex-rs/core/src/environment_context.rs
+++ b/codex-rs/core/src/environment_context.rs
@@ -309,7 +309,7 @@ mod tests {
             Some(AskForApproval::OnRequest),
             Some(workspace_write_policy(vec!["/repo"], false)),
             Some(Shell::Bash(BashShell {
-                shell_path: "/bin/bash".into(),
+                shell_path: crate::shell::system_bash_path(),
                 bashrc_path: "/home/user/.bashrc".into(),
             })),
         );

--- a/codex-rs/core/src/exec_command/exec_command_params.rs
+++ b/codex-rs/core/src/exec_command/exec_command_params.rs
@@ -33,7 +33,7 @@ fn default_login() -> bool {
 }
 
 fn default_shell() -> String {
-    "/bin/bash".to_string()
+    crate::shell::system_bash_path()
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/codex-rs/core/src/exec_command/responses_api.rs
+++ b/codex-rs/core/src/exec_command/responses_api.rs
@@ -29,7 +29,7 @@ pub fn create_exec_command_tool_for_responses_api() -> ResponsesApiTool {
     properties.insert(
         "shell".to_string(),
         JsonSchema::String {
-            description: Some("The shell to use. Defaults to \"/bin/bash\".".to_string()),
+            description: Some("The shell to use. Defaults to the system bash path.".to_string()),
         },
     );
     properties.insert(

--- a/codex-rs/core/src/exec_command/session_manager.rs
+++ b/codex-rs/core/src/exec_command/session_manager.rs
@@ -376,7 +376,7 @@ PY"#
             cmd,
             yield_time_ms: 3_000,
             max_output_tokens: 1_000, // large enough to avoid truncation here
-            shell: "/bin/bash".to_string(),
+            shell: crate::shell::system_bash_path(),
             login: false,
         };
         let initial_output = match session_manager

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -1,6 +1,7 @@
 use serde::Deserialize;
 use serde::Serialize;
 use shlex;
+use std::path::Path;
 use std::path::PathBuf;
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
@@ -103,6 +104,62 @@ impl Shell {
             Shell::Unknown => None,
         }
     }
+}
+
+pub fn system_bash_path() -> String {
+    system_bash_path_impl().unwrap_or_else(|| "/bin/bash".to_string())
+}
+
+fn system_bash_path_impl() -> Option<String> {
+    #[cfg(unix)]
+    {
+        if let Some(path) = std::env::var("SHELL")
+            .ok()
+            .filter(|value| !value.is_empty())
+            .filter(|value| value.ends_with("bash"))
+            .and_then(|value| ensure_executable_path(&value))
+        {
+            return Some(path);
+        }
+
+        if let Some(path) = detect_bash_from_passwd() {
+            return Some(path);
+        }
+    }
+
+    which::which("bash")
+        .ok()
+        .and_then(|path| path.to_str().map(|value| value.to_string()))
+}
+
+#[cfg(unix)]
+fn detect_bash_from_passwd() -> Option<String> {
+    use libc::getpwuid;
+    use libc::getuid;
+    use std::ffi::CStr;
+
+    unsafe {
+        let uid = getuid();
+        let pw = getpwuid(uid);
+
+        if pw.is_null() {
+            return None;
+        }
+
+        let shell_path = CStr::from_ptr((*pw).pw_shell)
+            .to_string_lossy()
+            .into_owned();
+
+        if shell_path.ends_with("/bash") {
+            return ensure_executable_path(&shell_path);
+        }
+    }
+
+    None
+}
+
+fn ensure_executable_path(path: &str) -> Option<String> {
+    Path::new(path).exists().then(|| path.to_string())
 }
 
 fn format_shell_invocation_with_rc(
@@ -266,37 +323,38 @@ mod tests {
 
     #[tokio::test]
     async fn test_run_with_profile_bashrc_not_exists() {
+        let shell_path = system_bash_path();
         let shell = Shell::Bash(BashShell {
-            shell_path: "/bin/bash".to_string(),
+            shell_path: shell_path.clone(),
             bashrc_path: "/does/not/exist/.bashrc".to_string(),
         });
         let actual_cmd = shell.format_default_shell_invocation(vec!["myecho".to_string()]);
         assert_eq!(
             actual_cmd,
-            Some(vec![
-                "/bin/bash".to_string(),
-                "-lc".to_string(),
-                "myecho".to_string()
-            ])
+            Some(vec![shell_path, "-lc".to_string(), "myecho".to_string()])
         );
     }
 
     #[tokio::test]
     async fn test_run_with_profile_bash_escaping_and_execution() {
-        let shell_path = "/bin/bash";
+        let shell_path = system_bash_path();
 
         let cases = vec![
             (
                 vec!["myecho"],
-                vec![shell_path, "-lc", "source BASHRC_PATH && (myecho)"],
+                vec![
+                    shell_path.clone(),
+                    "-lc".to_string(),
+                    "source BASHRC_PATH && (myecho)".to_string(),
+                ],
                 Some("It works!\n"),
             ),
             (
                 vec!["bash", "-lc", "echo 'single' \"double\""],
                 vec![
-                    shell_path,
-                    "-lc",
-                    "source BASHRC_PATH && (echo 'single' \"double\")",
+                    shell_path.clone(),
+                    "-lc".to_string(),
+                    "source BASHRC_PATH && (echo 'single' \"double\")".to_string(),
                 ],
                 Some("single double\n"),
             ),
@@ -323,7 +381,7 @@ mod tests {
             )
             .unwrap();
             let shell = Shell::Bash(BashShell {
-                shell_path: shell_path.to_string(),
+                shell_path: shell_path.clone(),
                 bashrc_path: bashrc_path.to_str().unwrap().to_string(),
             });
 

--- a/codex-rs/core/src/unified_exec/mod.rs
+++ b/codex-rs/core/src/unified_exec/mod.rs
@@ -470,10 +470,11 @@ mod tests {
 
         let manager = UnifiedExecSessionManager::default();
 
+        let bash_invocation = [crate::shell::system_bash_path(), "-i".to_string()];
         let shell_a = manager
             .handle_request(UnifiedExecRequest {
                 session_id: None,
-                input_chunks: &["/bin/bash".to_string(), "-i".to_string()],
+                input_chunks: &bash_invocation,
                 timeout_ms: Some(2_500),
             })
             .await?;
@@ -613,10 +614,11 @@ mod tests {
 
         let manager = UnifiedExecSessionManager::default();
 
+        let bash_invocation = [crate::shell::system_bash_path(), "-i".to_string()];
         let open_shell = manager
             .handle_request(UnifiedExecRequest {
                 session_id: None,
-                input_chunks: &["/bin/bash".to_string(), "-i".to_string()],
+                input_chunks: &bash_invocation,
                 timeout_ms: Some(2_500),
             })
             .await?;

--- a/codex-rs/core/tests/suite/exec.rs
+++ b/codex-rs/core/tests/suite/exec.rs
@@ -104,7 +104,8 @@ async fn exit_command_not_found_is_ok() {
     }
 
     let tmp = TempDir::new().expect("should be able to create temp dir");
-    let cmd = vec!["/bin/bash", "-c", "nonexistent_command_12345"];
+    let bash = codex_core::shell::system_bash_path();
+    let cmd = vec![bash.as_str(), "-c", "nonexistent_command_12345"];
     run_test_cmd(tmp, cmd).await.unwrap();
 }
 

--- a/codex-rs/core/tests/suite/user_notification.rs
+++ b/codex-rs/core/tests/suite/user_notification.rs
@@ -35,7 +35,7 @@ async fn summarize_context_three_requests_and_instructions() -> anyhow::Result<(
     let notify_script = notify_dir.path().join("notify.sh");
     std::fs::write(
         &notify_script,
-        r#"#!/bin/bash
+        r#"#!/usr/bin/env bash
 set -e
 echo -n "${@: -1}" > $(dirname "${0}")/notify.txt"#,
     )?;

--- a/codex-rs/protocol-ts/generate-ts
+++ b/codex-rs/protocol-ts/generate-ts
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
- add a helper that resolves the system bash path and use it as the default shell in exec-related code and tests
- refresh tests and user notification scripts to invoke bash via the detected path or `/usr/bin/env`
- update bash-based utility scripts to use `/usr/bin/env bash` for portability and clarify API docs about the shell default

## Testing
- cargo test -p codex-core --lib

------
https://chatgpt.com/codex/tasks/task_e_68fa5f90eaec832fb0241d9bc2fadac1