### PR TITLE
Add Multipass setup helper and Landlock readiness checks

### DIFF
--- a/scripts/codex-environment-setup.sh
+++ b/scripts/codex-environment-setup.sh
@@ -8,5 +8,6 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 "${script_dir}/ensure_nix.sh"
+"${script_dir}/ensure_multipass.sh"
 "${script_dir}/prefetch_ratatui_git_dependency.sh"
 "${script_dir}/install_darcs.sh"

--- a/scripts/ensure_multipass.sh
+++ b/scripts/ensure_multipass.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensures that Multipass is installed and configured to provide a kernel with
+# Landlock support. On Linux this means preferring the QEMU driver (which boots
+# full virtual machines with their own kernels) instead of the default LXD
+# driver that reuses the host kernel.
+
+maybe_sudo() {
+  if [[ ${EUID:-$(id -u)} -eq 0 ]]; then
+    "$@"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    "$@"
+  fi
+}
+
+install_multipass_linux() {
+  if command -v snap >/dev/null 2>&1; then
+    if snap list multipass >/dev/null 2>&1; then
+      return 0
+    fi
+    maybe_sudo snap install multipass --classic || return 1
+    return 0
+  fi
+
+  if command -v apt-get >/dev/null 2>&1; then
+    export DEBIAN_FRONTEND=noninteractive
+    maybe_sudo apt-get update
+    maybe_sudo apt-get install -y multipass
+    return 0
+  fi
+
+  return 1
+}
+
+install_multipass_darwin() {
+  if command -v brew >/dev/null 2>&1; then
+    brew list --versions multipass >/dev/null 2>&1 || brew install multipass
+    return 0
+  fi
+  return 1
+}
+
+ensure_linux_driver() {
+  local driver
+  if ! driver=$(multipass get local.driver 2>/dev/null); then
+    # Older Multipass releases may not support querying the driver; assume
+    # defaults in that case.
+    return 0
+  fi
+
+  driver=${driver,,}
+  if [[ "${driver}" == "qemu" ]]; then
+    return 0
+  fi
+
+  echo "ensure_multipass.sh: configuring Multipass to use the 'qemu' driver for Landlock support" >&2
+  if multipass set local.driver=qemu >/dev/null 2>&1; then
+    return 0
+  fi
+
+  echo "ensure_multipass.sh: failed to switch Multipass to the 'qemu' driver; Landlock support depends on the host kernel" >&2
+  return 1
+}
+
+case "$(uname -s)" in
+  Linux)
+    if ! command -v multipass >/dev/null 2>&1; then
+      install_multipass_linux || true
+    fi
+    ;;
+  Darwin)
+    if ! command -v multipass >/dev/null 2>&1; then
+      install_multipass_darwin || true
+    fi
+    ;;
+  *)
+    # Unsupported platform; nothing to do.
+    :
+    ;;
+ esac
+
+if ! command -v multipass >/dev/null 2>&1; then
+  echo "ensure_multipass.sh: Multipass is not available; install it manually if you plan to run ./vm-test.sh" >&2
+  exit 0
+fi
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  ensure_linux_driver || true
+fi
+
+multipass version >/dev/null 2>&1 || true

--- a/vm-test.sh
+++ b/vm-test.sh
@@ -31,6 +31,58 @@ necessary), and executes ./nixos-test.sh inside the virtual machine.
 EOF
 }
 
+require_linux_qemu_driver() {
+  if [[ "$(uname -s)" != "Linux" ]]; then
+    return 0
+  fi
+
+  local driver
+  driver=$(multipass get local.driver 2>/dev/null || echo "")
+  if [[ -z "${driver}" ]]; then
+    return 0
+  fi
+
+  driver=${driver,,}
+  if [[ "${driver}" == "qemu" ]]; then
+    return 0
+  fi
+
+  cat <<EOF >&2
+vm-test.sh: Multipass is configured to use the '${driver}' driver, which reuses the host kernel.
+Landlock support requires the 'qemu' driver. Run 'multipass set local.driver=qemu' (or
+scripts/ensure_multipass.sh) and try again.
+EOF
+  exit 1
+}
+
+check_vm_landlock() {
+  local check_script
+  local IFS=
+  read -r -d '' check_script <<'EOS' || true
+set -euo pipefail
+if [[ -e /sys/kernel/security/landlock/features ]]; then
+  exit 0
+fi
+if [[ -f /proc/config.gz ]] && zgrep -q "CONFIG_SECURITY_LANDLOCK=y" /proc/config.gz 2>/dev/null; then
+  exit 0
+fi
+config="/boot/config-$(uname -r)"
+if [[ -f "${config}" ]] && grep -q "CONFIG_SECURITY_LANDLOCK=y" "${config}"; then
+  exit 0
+fi
+exit 1
+EOS
+
+  if ! multipass exec "$VM_NAME" -- bash -lc "$check_script"; then
+    cat <<EOF >&2
+vm-test.sh: Multipass instance '$VM_NAME' does not appear to support Landlock.
+Ensure the guest kernel enables CONFIG_SECURITY_LANDLOCK (Ubuntu 22.04+). Recreate the VM
+after updating Multipass or switch drivers if necessary.
+EOF
+    exit 1
+  fi
+}
+
 ROOT=$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null)
 if [[ -z "${ROOT:-}" ]]; then
   echo "vm-test.sh: failed to locate repository root" >&2
@@ -98,6 +150,8 @@ EOF
   exit 1
 fi
 
+require_linux_qemu_driver
+
 DELETE_ON_EXIT=0
 
 if multipass info "$VM_NAME" >/dev/null 2>&1; then
@@ -111,6 +165,14 @@ fi
 if [[ "$KEEP_VM_FLAG" == "1" ]]; then
   DELETE_ON_EXIT=0
 fi
+
+if ! multipass start "$VM_NAME" >/dev/null 2>&1; then
+  echo "vm-test.sh: failed to start Multipass instance '$VM_NAME'" >&2
+  exit 1
+fi
+
+echo "==> Checking Landlock support in '$VM_NAME'"
+check_vm_landlock
 
 TMP_ARCHIVE=$(mktemp -t codex-vm-src.XXXXXX.tar.gz)
 


### PR DESCRIPTION
## Summary
- add a setup helper that installs Multipass when possible and switches Linux hosts to the qemu driver for Landlock support
- hook the Multipass helper into the Codex environment bootstrap script
- update vm-test.sh to enforce the qemu driver on Linux and verify Landlock support inside the guest before running tests

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fadf158ebc832f8470805f3517d494