### PR TITLE
Ensure Multipass installs via snap fallback

### DIFF
--- a/scripts/ensure_multipass.sh
+++ b/scripts/ensure_multipass.sh
@@ -21,15 +21,35 @@ install_multipass_linux() {
     if snap list multipass >/dev/null 2>&1; then
       return 0
     fi
-    maybe_sudo snap install multipass --classic || return 1
-    return 0
+    if maybe_sudo snap install multipass --classic; then
+      return 0
+    fi
   fi
 
   if command -v apt-get >/dev/null 2>&1; then
     export DEBIAN_FRONTEND=noninteractive
+
+    # Multipass is primarily distributed as a snap.  If snapd is not available
+    # yet, attempt to install it via apt so we can fall back to the snap
+    # installer.
+    if ! command -v snap >/dev/null 2>&1; then
+      maybe_sudo apt-get update || true
+      if maybe_sudo apt-get install -y snapd; then
+        if command -v snap >/dev/null 2>&1; then
+          if snap list multipass >/dev/null 2>&1; then
+            return 0
+          fi
+          if maybe_sudo snap install multipass --classic; then
+            return 0
+          fi
+        fi
+      fi
+    fi
+
     maybe_sudo apt-get update
-    maybe_sudo apt-get install -y multipass
-    return 0
+    if maybe_sudo apt-get install -y multipass; then
+      return 0
+    fi
   fi
 
   return 1


### PR DESCRIPTION
## Summary
- add a snap-based installation path for Multipass when apt packages are unavailable
- fall back to installing snapd via apt so the snap installer can run automatically
- keep the existing apt-based fallback if a distribution provides Multipass packages

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68faf35bc7d0832fb6dae84d72984eed