### PR TITLE
Update TypeScript test for git repo check message

### DIFF
--- a/sdk/typescript/tests/run.test.ts
+++ b/sdk/typescript/tests/run.test.ts
@@ -339,7 +339,7 @@ describe("Codex", () => {
         workingDirectory,
       });
       await expect(thread.run("use custom working directory")).rejects.toThrow(
-        /Not inside a trusted directory/,
+        /Not inside a Git or Darcs repository/,
       );
     } finally {
       await close();


### PR DESCRIPTION
## Summary
- align the Codex TypeScript SDK run.test expectation with the updated CLI error text when running outside a Git or Darcs repository

## Testing
- pnpm test
- ./vm-test.sh

------
https://chatgpt.com/codex/tasks/task_e_68fe5b768e00832f82994b31f705f349