### PR TITLE
Document Darcs exec verification progress

### DIFF
--- a/docs/darcs-testing-plan.md
+++ b/docs/darcs-testing-plan.md
@@ -57,6 +57,16 @@ repositories behave on par with Git across the Codex product surface.
   Darcs CLI appears exactly once and includes the CLI warning when PATH lacks
   `darcs`.
 
+  - ✅ `codex exec` launched inside a Darcs workspace printed `revision: Darcs` in
+    the config summary and appended the onboarding guidance describing Darcs CLI
+    workflows before our prompt was echoed.【e56847†L1-L14】
+  - ✅ Running the same command from outside any repository exited immediately
+    with the expected "Not inside a Git or Darcs repository" gating message.【5ab290†L1-L3】
+  - ✅ Invoking `codex exec` with `PATH` stripped to remove `darcs` surfaced the
+    revision warning in the config summary and recorded the missing-CLI guidance
+    in the session rollout log, confirming the onboarding message appears once
+    when tooling is absent.【8361e6†L1-L21】【d783eb†L1-L15】
+
 ### Diff & metadata plumbing
 
 - From the TUI `/diff` view, confirm it invokes `darcs::workspace_diff`,

--- a/docs/queues/darcs.md
+++ b/docs/queues/darcs.md
@@ -156,5 +156,5 @@ Carry out the verification steps described in [docs/darcs-testing-plan.md](../da
 #### Progress
 
 - ✅ Automated regression tests covering Darcs metadata, guidance, snapshots, and cloud tasks succeed with `darcs` 2.18.4 installed.【263e8d†L1-L27】【90eca2†L1-L9】【7ae0b3†L1-L15】【8a2167†L1-L25】【7aa85d†L1-L13】【62df51†L1-L5】
-- ⚠️ Manual functional verification (TUI flows, exec/trust, release tooling, negative PATH scenarios, cross-platform checks) still needs to be performed.
+- 🟡 Manual functional verification (TUI flows, exec/trust, release tooling, negative PATH scenarios, cross-platform checks) is under way: `codex exec` now verified Darcs detection, outside-repo gating, and the missing-CLI warning in alignment with the testing plan; remaining manual flows (diff viewer, rollouts, snapshots, release, cross-platform) are still outstanding.【F:docs/darcs-testing-plan.md†L48-L57】
 - ⚠️ `cargo test --workspace --all-features` currently fails in this sandbox because the Landlock-backed `codex-exec` tests error with `Sandbox(LandlockRestrict)`; reruns require a host with Landlock enabled.【7bdde7†L1-L19】


### PR DESCRIPTION
## Summary
- record the manual codex exec verification results in the Darcs testing plan, covering Darcs detection, repo gating, and missing-CLI guidance
- update the Darcs queue progress note to reflect that repository detection onboarding checks are now complete while other manual scenarios remain pending

## Testing
- /workspace/codex/codex-rs/target/debug/codex exec "say hi" (within Darcs repo)
- /workspace/codex/codex-rs/target/debug/codex exec "say hi" (outside any repo)
- env PATH=/nonexistent /workspace/codex/codex-rs/target/debug/codex exec "say hi"


------
https://chatgpt.com/codex/tasks/task_e_68fe857b5e48832f80f894026450e0c8