### PR TITLE
Record accurate timestamp for multipass findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ In the codex-rs folder where the rust code lives:
 - Use method references over closures when possible per https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure_for_method_calls
 - Skip clippy cleanups that rely on unstable language features (for example, let chains that require nightly).
 - When writing tests, prefer comparing the equality of entire objects over fields one by one.
+- When documenting time-sensitive findings, always record actual UTC timestamps retrieved from a real command (for example, `date -u +"%Y-%m-%d %H:%M:%SZ"`) instead of inventing values.
 
 Run `just fmt` (in `codex-rs` directory) automatically after making Rust code changes; do not ask for approval to run it. Before finalizing a change to `codex-rs`, run `just fix -p <project>` (in `codex-rs` directory) to fix any linter issues in the code. Prefer scoping with `-p` to avoid slow workspace‑wide Clippy builds; only run `just fix` without `-p` if you changed shared crates. Additionally, run the tests:
 

--- a/docs/multipass_landlock_plan.md
+++ b/docs/multipass_landlock_plan.md
@@ -9,6 +9,9 @@ The immediate symptom is that `./vm-test.sh` exits before running any checks bec
 1. **Baseline discovery**
    - Run `command -v multipass` and `multipass version` (guarded with `if command -v multipass >/dev/null`) to confirm the binary is truly absent or determine whether it was installed in a non-standard location.
    - Inspect `scripts/ensure_multipass.sh` for gating environment variables such as `INSTALL_MULTIPASS_SKIP` or `INSTALL_MULTIPASS_FORCE` and document their defaults so subsequent reruns of the setup script can be controlled deterministically.
+   - **Findings (2025-10-26 21:29:18Z)**
+     - `multipass` is not present on `PATH` (`command -v multipass` returned no result), so `multipass version` was not runnable.
+     - `scripts/ensure_multipass.sh` does not define or consult any gating environment variables; installation attempts are driven solely by runtime detection of `snap`, `apt-get`, and `brew` availability.
 
 2. **Capture provisioning metadata**
    - Collect the timestamped setup logs from `/tmp/codex-setup*.log` or the automation hook output to understand which setup iteration removed or skipped Multipass.


### PR DESCRIPTION
## Summary
- update the Multipass Landlock plan to capture the baseline discovery timestamp using the current UTC time
- add an agent note requiring real UTC timestamps when documenting time-sensitive findings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fe8ed175f4832fb182d6079a439f72