### PR TITLE
Document APT repository findings for Multipass

### DIFF
--- a/docs/multipass_landlock_plan.md
+++ b/docs/multipass_landlock_plan.md
@@ -72,6 +72,10 @@ The immediate symptom is that `./vm-test.sh` exits before running any checks bec
    - Identify official `.deb` artifacts from Canonical (see https://multipass.run/download/linux) and confirm whether they can be downloaded with `curl`/`wget` inside the sandbox.
    - Validate checksums against the published SHA256 values and store them alongside the downloaded artifacts so subsequent CI runs can reuse the same binary without re-downloading.
    - If direct installation fails because the package expects system services that are unavailable, capture the failing maintainer scripts and evaluate whether they can be stubbed or skipped.
+   - **Findings (2025-10-27 04:31:36Z)**
+     - Requests to `https://multipass.run` follow an HTTP 301 redirect to `https://canonical.com/multipass`, where the proxy at `proxy:8080` responds with `HTTP/1.1 403 Forbidden`; the MITM proxy therefore blocks fetching Canonical-hosted installers directly from the container.
+     - Direct access to Canonical APIs (for example, `https://api.snapcraft.io/api/v1/snaps/details/multipass`) fails with the same proxy-level 403, so downloading Snap metadata or `.deb` assets from Canonical mirrors is currently impossible.
+     - GitHub remains reachable: `https://api.github.com/repos/canonical/multipass/releases/latest` lists only macOS and Windows artifacts for v1.16.1, and downloading `multipass-1.16.1+mac-Darwin.pkg` (SHA256 `758d10dc1b71872b0ee7a17070b93fc788dba5ba45c36b980e42fd895d273489`) succeeds, confirming an alternate trusted source even though no Linux `.deb` is published alongside that release.
 
 ## Phase 4 – Validate virtualization prerequisites
 

--- a/docs/multipass_landlock_plan.md
+++ b/docs/multipass_landlock_plan.md
@@ -63,6 +63,10 @@ The immediate symptom is that `./vm-test.sh` exits before running any checks bec
    - Inspect `apt-cache policy multipass` and `apt-cache show multipass` to confirm package availability and required repository components.
    - Verify that `apt-get update` succeeds and that Multipass dependencies (notably `qemu`, `libvirt-bin`, and kernel modules) can be installed without conflicting with the base image.
    - Capture the output of `apt-get install --dry-run multipass` to enumerate the exact dependency chain and identify pre/post-install scripts that might fail under sandboxed conditions.
+   - **Findings (2025-10-27 04:07:12Z)**
+     - `apt-get update` completed for the Ubuntu archives but emitted a warning because the third-party `https://mise.jdx.dev` repository returned HTTP 403 responses; the failure was ignored and cached indices were reused.
+     - `apt-cache policy multipass`, `apt-cache show multipass`, and `apt-get install --dry-run multipass` all report “Unable to locate package multipass,” indicating that the package is absent from the default Noble repositories.
+     - `apt-cache search multipass` only lists the unrelated `ruby-omniauth-multipassword` package, confirming that no Multipass binary is currently published via APT for this release.
 
 3. **Fallback installers**
    - Identify official `.deb` artifacts from Canonical (see https://multipass.run/download/linux) and confirm whether they can be downloaded with `curl`/`wget` inside the sandbox.


### PR DESCRIPTION
## Summary
- record that apt repositories on Ubuntu Noble do not publish the multipass package
- note the proxy warning from apt-get update and the absence of related packages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68feefb790c4832f876ddc339749ebd6