### PR TITLE
Add persistent logging to environment setup scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ In the codex-rs folder where the rust code lives:
 - Crate names are prefixed with `codex-`. For example, the `core` folder's crate is named `codex-core`
 - When using format! and you can inline variables into {}, always do that.
 - Install any commands the repo relies on (for example `just`, `rg`, or `cargo-insta`) if they aren't already available before running instructions here.
+- When writing shell scripts, avoid negated conditionals that immediately `exit $?`; capture the status before any negation or use `|| exit $?` so non-zero exit codes propagate.
 - Never add or modify any code related to `CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR` or `CODEX_SANDBOX_ENV_VAR`.
   - You operate in a sandbox where `CODEX_SANDBOX_NETWORK_DISABLED=1` will be set whenever you use the `shell` tool. Any existing code that uses `CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR` was authored with this fact in mind. It is often used to early exit out of tests that the author knew you would not be able to run given your sandbox limitations.
   - Similarly, when you spawn a process using Seatbelt (`/usr/bin/sandbox-exec`), `CODEX_SANDBOX=seatbelt` will be set on the child process. Integration tests that want to run Seatbelt themselves cannot be run under Seatbelt, so checks for `CODEX_SANDBOX=seatbelt` are also often used to early exit out of tests, as appropriate.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,6 @@ In the codex-rs folder where the rust code lives:
 - Crate names are prefixed with `codex-`. For example, the `core` folder's crate is named `codex-core`
 - When using format! and you can inline variables into {}, always do that.
 - Install any commands the repo relies on (for example `just`, `rg`, or `cargo-insta`) if they aren't already available before running instructions here.
-- When writing shell scripts, avoid negated conditionals that immediately `exit $?`; capture the status before any negation or use `|| exit $?` so non-zero exit codes propagate.
 - Never add or modify any code related to `CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR` or `CODEX_SANDBOX_ENV_VAR`.
   - You operate in a sandbox where `CODEX_SANDBOX_NETWORK_DISABLED=1` will be set whenever you use the `shell` tool. Any existing code that uses `CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR` was authored with this fact in mind. It is often used to early exit out of tests that the author knew you would not be able to run given your sandbox limitations.
   - Similarly, when you spawn a process using Seatbelt (`/usr/bin/sandbox-exec`), `CODEX_SANDBOX=seatbelt` will be set on the child process. Integration tests that want to run Seatbelt themselves cannot be run under Seatbelt, so checks for `CODEX_SANDBOX=seatbelt` are also often used to early exit out of tests, as appropriate.
@@ -21,6 +20,10 @@ Run `just fmt` (in `codex-rs` directory) automatically after making Rust code ch
 1. Run the test for the specific project that was changed. For example, if changes were made in `codex-rs/tui`, run `cargo test -p codex-tui`.
 2. Once those pass, if any changes were made in common, core, or protocol, run the complete test suite with `cargo test --all-features`.
    When running interactively, ask the user before running `just fix` to finalize. `just fmt` does not require approval. project-specific or individual tests can be run without asking the user, but do ask the user before running the complete test suite.
+
+## Shell scripts
+
+- Avoid negated conditionals that immediately `exit $?`; capture the failing status before using negation or append `|| exit $?` so non-zero exit codes propagate.
 
 ## TUI style conventions
 

--- a/scripts/codex-environment-setup.sh
+++ b/scripts/codex-environment-setup.sh
@@ -42,22 +42,13 @@ run_step() {
   return "${status}"
 }
 
-run_step_or_exit() {
-  if run_step "$@"; then
-    return 0
-  fi
-
-  local status=$?
-  exit "${status}"
-}
-
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 log_info "codex-environment-setup.sh starting (PID $$)"
 
-run_step_or_exit "ensure_nix.sh" "${script_dir}/ensure_nix.sh"
-run_step_or_exit "ensure_multipass.sh" "${script_dir}/ensure_multipass.sh"
-run_step_or_exit "prefetch_ratatui_git_dependency.sh" "${script_dir}/prefetch_ratatui_git_dependency.sh"
-run_step_or_exit "install_darcs.sh" "${script_dir}/install_darcs.sh"
+run_step "ensure_nix.sh" "${script_dir}/ensure_nix.sh" || exit $?
+run_step "ensure_multipass.sh" "${script_dir}/ensure_multipass.sh" || exit $?
+run_step "prefetch_ratatui_git_dependency.sh" "${script_dir}/prefetch_ratatui_git_dependency.sh" || exit $?
+run_step "install_darcs.sh" "${script_dir}/install_darcs.sh" || exit $?
 
 log_info "codex-environment-setup.sh completed successfully"

--- a/scripts/codex-environment-setup.sh
+++ b/scripts/codex-environment-setup.sh
@@ -42,24 +42,22 @@ run_step() {
   return "${status}"
 }
 
+run_step_or_exit() {
+  if run_step "$@"; then
+    return 0
+  fi
+
+  local status=$?
+  exit "${status}"
+}
+
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 log_info "codex-environment-setup.sh starting (PID $$)"
 
-if ! run_step "ensure_nix.sh" "${script_dir}/ensure_nix.sh"; then
-  exit $?
-fi
-
-if ! run_step "ensure_multipass.sh" "${script_dir}/ensure_multipass.sh"; then
-  exit $?
-fi
-
-if ! run_step "prefetch_ratatui_git_dependency.sh" "${script_dir}/prefetch_ratatui_git_dependency.sh"; then
-  exit $?
-fi
-
-if ! run_step "install_darcs.sh" "${script_dir}/install_darcs.sh"; then
-  exit $?
-fi
+run_step_or_exit "ensure_nix.sh" "${script_dir}/ensure_nix.sh"
+run_step_or_exit "ensure_multipass.sh" "${script_dir}/ensure_multipass.sh"
+run_step_or_exit "prefetch_ratatui_git_dependency.sh" "${script_dir}/prefetch_ratatui_git_dependency.sh"
+run_step_or_exit "install_darcs.sh" "${script_dir}/install_darcs.sh"
 
 log_info "codex-environment-setup.sh completed successfully"

--- a/scripts/codex-environment-setup.sh
+++ b/scripts/codex-environment-setup.sh
@@ -5,9 +5,61 @@ set -euo pipefail
 # first created. It installs required tooling and warms dependency caches so
 # subsequent builds and tests can run without network access.
 
+timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+log_dir=${CODEX_ENV_LOG_DIR:-/var/tmp/codex-setup}
+mkdir -p "${log_dir}"
+
+log_file=${CODEX_ENV_SETUP_LOG_FILE:-"${log_dir}/$(timestamp)-codex-environment-setup-$$.log"}
+touch "${log_file}"
+export CODEX_ENV_SETUP_LOG_FILE="${log_file}"
+
+exec > >(tee -a "${log_file}")
+exec 2>&1
+
+log_info() {
+  printf '[%s] [codex-environment-setup] %s\n' "$(timestamp)" "$*"
+}
+
+log_error() {
+  printf '[%s] [codex-environment-setup] ERROR: %s\n' "$(timestamp)" "$*"
+}
+
+run_step() {
+  local description=$1
+  shift
+
+  log_info "Starting ${description}"
+  if "$@"; then
+    log_info "Finished ${description}"
+    return 0
+  fi
+
+  local status=$?
+  log_error "${description} failed with exit code ${status}"
+  return "${status}"
+}
+
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
-"${script_dir}/ensure_nix.sh"
-"${script_dir}/ensure_multipass.sh"
-"${script_dir}/prefetch_ratatui_git_dependency.sh"
-"${script_dir}/install_darcs.sh"
+log_info "codex-environment-setup.sh starting (PID $$)"
+
+if ! run_step "ensure_nix.sh" "${script_dir}/ensure_nix.sh"; then
+  exit $?
+fi
+
+if ! run_step "ensure_multipass.sh" "${script_dir}/ensure_multipass.sh"; then
+  exit $?
+fi
+
+if ! run_step "prefetch_ratatui_git_dependency.sh" "${script_dir}/prefetch_ratatui_git_dependency.sh"; then
+  exit $?
+fi
+
+if ! run_step "install_darcs.sh" "${script_dir}/install_darcs.sh"; then
+  exit $?
+fi
+
+log_info "codex-environment-setup.sh completed successfully"

--- a/scripts/ensure_multipass.sh
+++ b/scripts/ensure_multipass.sh
@@ -6,6 +6,42 @@ set -euo pipefail
 # full virtual machines with their own kernels) instead of the default LXD
 # driver that reuses the host kernel.
 
+timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+log_dir=${CODEX_ENV_LOG_DIR:-/var/tmp/codex-setup}
+mkdir -p "${log_dir}"
+
+if [[ -n "${CODEX_ENV_SETUP_LOG_FILE:-}" ]]; then
+  log_file="${CODEX_ENV_SETUP_LOG_FILE}"
+else
+  log_file="${log_dir}/$(timestamp)-ensure_multipass-$$.log"
+fi
+
+exec > >(tee -a "${log_file}")
+exec 2>&1
+
+log() {
+  local level=$1
+  shift
+  printf '[%s] [ensure_multipass] %s: %s\n' "$(timestamp)" "${level}" "$*"
+}
+
+log_info() {
+  log INFO "$@"
+}
+
+log_warn() {
+  log WARN "$@"
+}
+
+log_error() {
+  log ERROR "$@"
+}
+
+log_info "ensure_multipass.sh starting (PID $$)"
+
 maybe_sudo() {
   if [[ ${EUID:-$(id -u)} -eq 0 ]]; then
     "$@"
@@ -17,49 +53,112 @@ maybe_sudo() {
 }
 
 install_multipass_linux() {
+  log_info "Attempting Linux installation paths for Multipass"
+
   if command -v snap >/dev/null 2>&1; then
+    log_info "snap detected; checking for existing Multipass snap"
     if snap list multipass >/dev/null 2>&1; then
+      log_info "Multipass snap is already installed"
       return 0
+    else
+      local status=$?
+      log_warn "snap list multipass exited with status ${status}; attempting snap installation"
     fi
+
     if maybe_sudo snap install multipass --classic; then
+      log_info "Successfully installed Multipass via snap"
       return 0
+    else
+      local status=$?
+      log_warn "snap install multipass --classic failed with exit code ${status}"
     fi
   fi
 
   if command -v apt-get >/dev/null 2>&1; then
+    log_info "apt-get detected; preparing to use APT installers"
     export DEBIAN_FRONTEND=noninteractive
 
     # Multipass is primarily distributed as a snap.  If snapd is not available
     # yet, attempt to install it via apt so we can fall back to the snap
     # installer.
     if ! command -v snap >/dev/null 2>&1; then
-      maybe_sudo apt-get update || true
+      log_info "snap command not present; attempting to install snapd via apt"
+
+      if maybe_sudo apt-get update; then
+        log_info "apt-get update completed before snapd installation"
+      else
+        local status=$?
+        log_warn "apt-get update failed with exit code ${status} before snapd installation; continuing"
+      fi
+
       if maybe_sudo apt-get install -y snapd; then
+        log_info "Successfully installed snapd"
         if command -v snap >/dev/null 2>&1; then
+          log_info "snap command now available; checking for Multipass snap"
           if snap list multipass >/dev/null 2>&1; then
+            log_info "Multipass snap is already installed after installing snapd"
             return 0
+          else
+            local status=$?
+            log_warn "snap list multipass exited with status ${status} after installing snapd"
           fi
+
           if maybe_sudo snap install multipass --classic; then
+            log_info "Successfully installed Multipass via snap after installing snapd"
             return 0
+          else
+            local status=$?
+            log_warn "snap install multipass --classic failed with exit code ${status} after installing snapd"
           fi
+        else
+          log_warn "snap command still unavailable after installing snapd"
         fi
+      else
+        local status=$?
+        log_warn "apt-get install -y snapd failed with exit code ${status}"
       fi
     fi
 
-    maybe_sudo apt-get update
+    if maybe_sudo apt-get update; then
+      log_info "apt-get update completed before attempting direct Multipass install"
+    else
+      local status=$?
+      log_warn "apt-get update failed with exit code ${status} before direct Multipass install"
+    fi
+
     if maybe_sudo apt-get install -y multipass; then
+      log_info "Successfully installed Multipass via apt"
       return 0
+    else
+      local status=$?
+      log_warn "apt-get install -y multipass failed with exit code ${status}"
     fi
   fi
 
+  log_warn "All Linux installation attempts for Multipass failed"
   return 1
 }
 
 install_multipass_darwin() {
+  log_info "Attempting macOS installation paths for Multipass"
   if command -v brew >/dev/null 2>&1; then
-    brew list --versions multipass >/dev/null 2>&1 || brew install multipass
-    return 0
+    if brew list --versions multipass >/dev/null 2>&1; then
+      log_info "Multipass already installed via Homebrew"
+      return 0
+    fi
+
+    log_info "Installing Multipass via Homebrew"
+    if brew install multipass; then
+      log_info "Successfully installed Multipass via Homebrew"
+      return 0
+    else
+      local status=$?
+      log_warn "brew install multipass failed with exit code ${status}"
+      return "${status}"
+    fi
   fi
+
+  log_warn "Homebrew is not available; cannot install Multipass on macOS"
   return 1
 }
 
@@ -76,39 +175,67 @@ ensure_linux_driver() {
     return 0
   fi
 
-  echo "ensure_multipass.sh: configuring Multipass to use the 'qemu' driver for Landlock support" >&2
+  log_info "Configuring Multipass to use the 'qemu' driver for Landlock support"
   if multipass set local.driver=qemu >/dev/null 2>&1; then
     return 0
   fi
 
-  echo "ensure_multipass.sh: failed to switch Multipass to the 'qemu' driver; Landlock support depends on the host kernel" >&2
+  log_warn "Failed to switch Multipass to the 'qemu' driver; Landlock support depends on the host kernel"
   return 1
 }
 
 case "$(uname -s)" in
   Linux)
+    log_info "Detected Linux host"
     if ! command -v multipass >/dev/null 2>&1; then
-      install_multipass_linux || true
+      if install_multipass_linux; then
+        log_info "Installation routine reported success"
+      else
+        status=$?
+        log_warn "Installation routine exited with status ${status}; Multipass may still be unavailable"
+        unset status
+      fi
     fi
     ;;
   Darwin)
+    log_info "Detected macOS host"
     if ! command -v multipass >/dev/null 2>&1; then
-      install_multipass_darwin || true
+      if install_multipass_darwin; then
+        log_info "Installation routine reported success"
+      else
+        status=$?
+        log_warn "Installation routine exited with status ${status}; Multipass may still be unavailable"
+        unset status
+      fi
     fi
     ;;
   *)
     # Unsupported platform; nothing to do.
-    :
+    log_warn "Unsupported platform '$(uname -s)'; skipping Multipass installation"
     ;;
  esac
 
 if ! command -v multipass >/dev/null 2>&1; then
-  echo "ensure_multipass.sh: Multipass is not available; install it manually if you plan to run ./vm-test.sh" >&2
+  log_warn "Multipass is not available; install it manually if you plan to run ./vm-test.sh"
   exit 0
 fi
 
 if [[ "$(uname -s)" == "Linux" ]]; then
-  ensure_linux_driver || true
+  if ensure_linux_driver; then
+    log_info "Confirmed Multipass is configured to use the qemu driver"
+  else
+    status=$?
+    log_warn "Attempt to ensure the qemu driver exited with status ${status}"
+    unset status
+  fi
 fi
 
-multipass version >/dev/null 2>&1 || true
+if multipass version >/dev/null 2>&1; then
+  log_info "Successfully queried Multipass version"
+else
+  status=$?
+  log_warn "multipass version command failed with exit code ${status}"
+  unset status
+fi
+
+log_info "ensure_multipass.sh completed"


### PR DESCRIPTION
## Summary
- redirect codex-environment-setup.sh output into a persistent log file and report step results
- instrument ensure_multipass.sh to append to the shared log and describe each installer attempt

## Testing
- bash -n scripts/codex-environment-setup.sh
- bash -n scripts/ensure_multipass.sh

------
https://chatgpt.com/codex/tasks/task_e_68ff7712a61c832fba64f7379f9c4a57