### PR TITLE
Document blocked Multipass driver verification

### DIFF
--- a/docs/multipass_landlock_plan.md
+++ b/docs/multipass_landlock_plan.md
@@ -98,6 +98,9 @@ The immediate symptom is that `./vm-test.sh` exits before running any checks bec
 
 1. **Confirm Multipass driver selection**
    - After successful installation, run `multipass get local.driver` to confirm the `qemu` driver is active. If the driver reports `lxd` or `none`, determine why Multipass fell back and whether QEMU support can be forced via configuration.
+   - **Findings (2025-10-29 19:37:40Z)**
+     - `multipass` remains unavailable on `PATH` (`command -v multipass` produced no output), so the driver check cannot proceed until installation succeeds.
+     - Because the CLI is missing, `multipass get local.driver` could not be executed; this task is blocked pending restoration of Multipass.
 
 2. **Boot and inspect a micro VM**
    - Launch a minimal instance (`multipass launch --name landlock-check --cpus 1 --mem 512M --disk 5G --timeout 600 jammy`).


### PR DESCRIPTION
## Summary
- record that the Multipass CLI is still unavailable while attempting to verify the active driver
- note that the driver verification step remains blocked until Multipass is restored

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_69026ce27638832fbd6b9d68a968eba8